### PR TITLE
ユーザーのログアウト機能の実装

### DIFF
--- a/app/assets/stylesheets/_mypage.scss
+++ b/app/assets/stylesheets/_mypage.scss
@@ -215,6 +215,31 @@
       @include clearfix;
     }
     @include clearfix;
+
+    &__mypage-button {
+      display: block;
+      max-width: 320px;
+      height: 50px;
+      line-height: 48px;
+      font-size: 14px;
+      text-align: center;
+      margin: 64px auto;
+      background-color: $attention-color;
+      position: relative;
+      a{
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        color: $white-color;
+        &hover {
+          cursor: pointer;
+        }
+      }
+    }
   }
   @include clearfix;
 }

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -1,4 +1,7 @@
 class MypageController < ApplicationController
   def index
   end
+
+  def logout
+  end
 end

--- a/app/views/mypage/_leftcontent.html.haml
+++ b/app/views/mypage/_leftcontent.html.haml
@@ -1,0 +1,52 @@
+.main__left-content
+  %ul.main__left-content__menu
+    %li.main__left-content__menu-link.gray
+      = link_to "マイページ", '/', class: 'main__left-content__menu-link-a'
+    %li.main__left-content__menu-link
+      = link_to "お知らせ", '/', class: 'main__left-content__menu-link-a'
+    %li.main__left-content__menu-link
+      = link_to "やることリスト", '/', class: 'main__left-content__menu-link-a'
+    %li.main__left-content__menu-link
+      = link_to "いいね！一覧", '/', class: 'main__left-content__menu-link-a'
+    %li.main__left-content__menu-link
+      = link_to "出品する", '/', class: 'main__left-content__menu-link-a'
+    %li.main__left-content__menu-link
+      = link_to "出荷した商品-出品中", '/', class: 'main__left-content__menu-link-a'
+    %li.main__left-content__menu-link
+      = link_to "出荷した商品-取引中", '/', class: 'main__left-content__menu-link-a'
+    %li.main__left-content__menu-link
+      = link_to "出荷した商品-売却済み", '/', class: 'main__left-content__menu-link-a'
+    %li.main__left-content__menu-link
+      = link_to "購入した商品-取引中", '/', class: 'main__left-content__menu-link-a'
+    %li.main__left-content__menu-link
+      = link_to "購入した商品-過去の取引", '/', class: 'main__left-content__menu-link-a'
+    %li.main__left-content__menu-link
+      = link_to "ニュース一覧", '/', class: 'main__left-content__menu-link-a'
+    %li.main__left-content__menu-link
+      = link_to "評価一覧", '/', class: 'main__left-content__menu-link-a'
+    %li.main__left-content__menu-link
+      = link_to "ガイド", '/', class: 'main__left-content__menu-link-a'
+    %li.main__left-content__menu-link
+      = link_to "お問い合わせ", '/', class: 'main__left-content__menu-link-a'
+  %h2.main__left-content__title メルペイ
+  %ul.main__left-content__menu
+    %li.main__left-content__menu-link
+      = link_to "売上・振込申請", '/', class: 'main__left-content__menu-link-a'
+    %li.main__left-content__menu-link
+      = link_to "ポイント", '/', class: 'main__left-content__menu-link-a'
+  %h2.main__left-content__title 設定
+  %ul.main__left-content__menu
+    %li.main__left-content__menu-link
+      = link_to "プロフィール", '/', class: 'main__left-content__menu-link-a'
+    %li.main__left-content__menu-link
+      = link_to "発送元・お届け先住所変更", '/', class: 'main__left-content__menu-link-a'
+    %li.main__left-content__menu-link
+      = link_to "支払い方法", '/', class: 'main__left-content__menu-link-a'
+    %li.main__left-content__menu-link
+      = link_to "メール/パスワード", '/', class: 'main__left-content__menu-link-a'
+    %li.main__left-content__menu-link
+      = link_to "本人情報", '/', class: 'main__left-content__menu-link-a'
+    %li.main__left-content__menu-link
+      = link_to "電話番号の確認", '/', class: 'main__left-content__menu-link-a'
+    %li.main__left-content__menu-link
+      = link_to "ログアウト", logout_mypage_path, class: 'main__left-content__menu-link-a'

--- a/app/views/mypage/index.html.haml
+++ b/app/views/mypage/index.html.haml
@@ -2,58 +2,7 @@
   = render partial: 'shared/header'
   = render partial: 'shared/nav'
   %main.main
-    .main__left-content
-      %ul.main__left-content__menu
-        %li.main__left-content__menu-link.gray
-          = link_to "マイページ", '/', class: 'main__left-content__menu-link-a'
-        %li.main__left-content__menu-link
-          = link_to "お知らせ", '/', class: 'main__left-content__menu-link-a'
-        %li.main__left-content__menu-link
-          = link_to "やることリスト", '/', class: 'main__left-content__menu-link-a'
-        %li.main__left-content__menu-link
-          = link_to "いいね！一覧", '/', class: 'main__left-content__menu-link-a'
-        %li.main__left-content__menu-link
-          = link_to "出品する", '/', class: 'main__left-content__menu-link-a'
-        %li.main__left-content__menu-link
-          = link_to "出荷した商品-出品中", '/', class: 'main__left-content__menu-link-a'
-        %li.main__left-content__menu-link
-          = link_to "出荷した商品-取引中", '/', class: 'main__left-content__menu-link-a'
-        %li.main__left-content__menu-link
-          = link_to "出荷した商品-売却済み", '/', class: 'main__left-content__menu-link-a'
-        %li.main__left-content__menu-link
-          = link_to "購入した商品-取引中", '/', class: 'main__left-content__menu-link-a'
-        %li.main__left-content__menu-link
-          = link_to "購入した商品-過去の取引", '/', class: 'main__left-content__menu-link-a'
-        %li.main__left-content__menu-link
-          = link_to "ニュース一覧", '/', class: 'main__left-content__menu-link-a'
-        %li.main__left-content__menu-link
-          = link_to "評価一覧", '/', class: 'main__left-content__menu-link-a'
-        %li.main__left-content__menu-link
-          = link_to "ガイド", '/', class: 'main__left-content__menu-link-a'
-        %li.main__left-content__menu-link
-          = link_to "お問い合わせ", '/', class: 'main__left-content__menu-link-a'
-      %h2.main__left-content__title メルペイ
-      %ul.main__left-content__menu
-        %li.main__left-content__menu-link
-          = link_to "売上・振込申請", '/', class: 'main__left-content__menu-link-a'
-        %li.main__left-content__menu-link
-          = link_to "ポイント", '/', class: 'main__left-content__menu-link-a'
-      %h2.main__left-content__title 設定
-      %ul.main__left-content__menu
-        %li.main__left-content__menu-link
-          = link_to "プロフィール", '/', class: 'main__left-content__menu-link-a'
-        %li.main__left-content__menu-link
-          = link_to "発送元・お届け先住所変更", '/', class: 'main__left-content__menu-link-a'
-        %li.main__left-content__menu-link
-          = link_to "支払い方法", '/', class: 'main__left-content__menu-link-a'
-        %li.main__left-content__menu-link
-          = link_to "メール/パスワード", '/', class: 'main__left-content__menu-link-a'
-        %li.main__left-content__menu-link
-          = link_to "本人情報", '/', class: 'main__left-content__menu-link-a'
-        %li.main__left-content__menu-link
-          = link_to "電話番号の確認", '/', class: 'main__left-content__menu-link-a'
-        %li.main__left-content__menu-link
-          = link_to "ログアウト", '/', class: 'main__left-content__menu-link-a'
+    = render partial: 'leftcontent'
     .main__right-content
       .main__right-content__header{"style": "background-image: url('#{asset_path('background_01.jpg')}');"}
       %ul.main__right-content__tabs

--- a/app/views/mypage/logout.html.haml
+++ b/app/views/mypage/logout.html.haml
@@ -1,0 +1,10 @@
+#wrapper
+  = render partial: 'shared/header'
+  = render partial: 'shared/nav'
+  %main.main
+    = render partial: 'leftcontent'
+    .main__right-content
+      .main__right-content__mypage-button
+        =link_to "ログアウト", destroy_user_session_path, method: :delete 
+
+  = render partial: 'shared/footer'

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -32,7 +32,7 @@
               = link_to '#' do
                 やることリスト
             %li.after-login
-              = link_to user_mypage_index_path(current_user.id) do
+              = link_to mypage_index_path do
                 マイページ
         - else
           %ul.header__lower-contents__right-contents__menu

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,9 +9,13 @@ Rails.application.routes.draw do
     post 'login', to: 'devise/sessions#create', as: :user_session
     delete 'logout', to: 'devise/sessions#destroy', as: :destroy_user_session
   end
-  resources :users do
-    resources :mypage, only: [:index]
+  
+  resources :mypage, only: [:index]
+  as :mypage do
+    get 'logout', to: 'mypage#logout', as: :logout_mypage
   end
+
+
 
   
   root 'main#index'


### PR DESCRIPTION
# What
マイページにログアウトページへのリンクを設置
left contentはテンプレートファイルとして切り出した
ログアウト画面のビューを作成
ログアウトボタンでdevise/sessions#destroyを呼び出すことでユーザーのログアウトを可能にした

# Why
ユーザーがログアウトできるようにするため
<img width="1440" alt="logout-view" src="https://user-images.githubusercontent.com/56216409/69141258-b1917d00-0b07-11ea-87be-15538f387a4f.png">
![logout](https://user-images.githubusercontent.com/56216409/69141265-bb1ae500-0b07-11ea-810f-325512e4a094.gif)
