### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/assets/stylesheets/_products.scss
+++ b/app/assets/stylesheets/_products.scss
@@ -623,18 +623,27 @@ a {
         font-size: 30px;
         color: #fff;
         background: #385185;
+        &:hover {
+          opacity: .7;
+        }
       }
       .fa-twitter {
         @include product-media-icon;
         font-size: 30px;
         color: #fff;
         background: #5d9dc9;
+        &:hover {
+          opacity: .7;
+        }
       }
       .fa-pinterest {
         @include product-media-icon;
         color: #fff;
         background: #aa262a;
         font-size: 20px;
+        &:hover {
+          opacity: .7;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/_products.scss
+++ b/app/assets/stylesheets/_products.scss
@@ -490,6 +490,11 @@ a {
       .report-btn {
         @include product-btn;
         margin: 0 0 0 16px;
+        -webkit-transition: all ease-out .3s;
+        transition: all ease-out .3s;
+        &:hover {
+          opacity: .7;
+        }
       }
     }
     &__right {
@@ -677,6 +682,7 @@ a {
           position: relative;
           margin: 0;
           img {
+            object-fit: cover;
             position: absolute;
             top: 50%;
             transform: translate(0, -50%);
@@ -684,7 +690,8 @@ a {
             bottom: 0;
             left: 0;
             z-index: 1;
-            width: 100%;
+            width: 220px;
+            height: 220px;
           }
         }
         .product-box-body {

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -29,6 +29,8 @@ class ProductsController < ApplicationController
     else
       @postage = "着払い"
     end
+    @back_product = Product.where('id < ?', @product.id).first
+    @next_product = Product.where('id > ?', @product.id).first
     @seller_other_products = Product.where(user_id: @seller.id).order("id DESC").limit(6).where.not(id: @product.id)
     @category_other_products = Product.where(category_id: @category.id).order("id DESC").limit(6).where.not(id: @product.id)
   end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -24,11 +24,7 @@ class ProductsController < ApplicationController
     @seller = @product.user
     @category = @product.category
     @delivery = @product.delivery
-    if @delivery.responsibility.include?("出品者負担")
-      @postage = "送料込み"
-    else
-      @postage = "着払い"
-    end
+    @postage = @delivery.responsibility.include?("出品者負担") ? "送料込み" : "着払い"
     @back_product = Product.where('id < ?', @product.id).first
     @next_product = Product.where('id > ?', @product.id).first
     @seller_other_products = Product.where(user_id: @seller.id).order("id DESC").limit(6).where.not(id: @product.id)

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -19,6 +19,18 @@ class ProductsController < ApplicationController
   end
 
   def show
+    @product = Product.find(params[:id])
+    @images = @product.images
+    @seller = @product.user
+    @category = @product.category
+    @delivery = @product.delivery
+    if @delivery.responsibility.include?("出品者負担")
+      @postage = "送料込み"
+    else
+      @postage = "着払い"
+    end
+    @seller_other_products = Product.where(user_id: @seller.id).order("id DESC").limit(6).where.not(id: @product.id)
+    @category_other_products = Product.where(category_id: @category.id).order("id DESC").limit(6).where.not(id: @product.id)
   end
 
 private

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -27,7 +27,21 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     else
       # SNS情報が登録されていなければサインアップさせる
       @sns = info[:sns]
+
+      # 遷移先のビューで必要なデータ
       @status1 ="active"
+      @years = []
+        Date.today.year.downto(1900){ |year|
+          @years << year
+        }
+      @days = []
+      for day in 1..31 do
+        if day.to_s.length == 1
+          @days << "0" + "#{day}"
+        else
+          @days << day
+        end
+      end
       render "/signup/registration"
     end
   end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -2,5 +2,5 @@ class Image < ApplicationRecord
   # validates :image, presence: true
   belongs_to :product, inverse_of: :images
 
-  mount_uploader :images, ImageUploader
+  mount_uploader :image, ImageUploader
 end

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -91,12 +91,12 @@
             = f.submit 'コメントする', class: "product-mesage-submit"
     
     %ul.product-link-list
-      -unless @back_product.name.blank?
+      -unless @back_product.blank?
         %li.product-link-list__left
-          = link_to "#{@back_product.name}", "#"
-      -unless @next_product.name.blank?
+          = link_to "#{@back_product.name}", product_path(@back_product.id)
+      -unless @next_product.blank?
         %li.product-link-list__right
-          = link_to "#{@next_product.name}", "#"
+          = link_to "#{@next_product.name}", product_path(@next_product.id)
 
     .product-media-box
       %ul.product-media-box__list
@@ -137,7 +137,7 @@
           - unless @category_other_products.blank?
             -@category_other_products.each do |product|
               .product-introduction-box-content__product-box
-                = link_to "#" do
+                = link_to product_path(product.id) do
                   %figure.product-box-photo
                     = image_tag("/uploads/image/image/#{product.images[0][:id]}/#{product.images[0][:image]}")
                   .product-box-body

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -2,83 +2,78 @@
   = render partial: 'shared/header'
   %main.main
     .product-box-content
-      %h2.product-box-content__product-name 商品タイトル
+      %h2.product-box-content__product-name 
+        = @product.name
       .product-box-content__product-main-content
         .product-box-content__product-main-content__product-image
           .product-box-content__product-main-content__product-image__big
-            = image_tag "logo_white.svg"
+            = image_tag("/uploads/image/image/#{@images[0][:id]}/#{@images[0][:image]}")
           .product-box-content__product-main-content__product-image__others
-            .image-list
-              = image_tag "test_image.jpg"
-            .image-list
-              = image_tag "logo_white.svg"
-            .image-list
-              = image_tag "test_image2.jpg"
-            .image-list
-              = image_tag "logo_white.svg"
-            .image-list
-              = image_tag "test_image3.jpg"
-            .image-list
-              = image_tag "logo_white.svg"
+            -@images.each do |img|
+              .image-list
+                = image_tag("/uploads/image/image/#{img[:id]}/#{img[:image]}")
 
         %table.product-box-content__product-main-content__product-information
           %tbody
             %tr
               %th 出品者
               %td
-                = link_to "変数　名前", "#" 
+                = link_to "#{@seller.nickname}", "#" 
                 .seller-evalution
                   .seller-ratings
                     %i.fa.fa-smile-o
-                    %span 数
+                    %span 0
                   .seller-ratings
                     %i.fa.fa-meh-o
-                    %span 数
+                    %span 0
                   .seller-ratings
                     %i.fa.fa-frown-o
-                    %span 数
+                    %span 0
             %tr
               %th カテゴリー
               %td
-                = link_to "カテゴリー１", "#"
+                = link_to "#{@category.name}", "#"
                 = link_to "カテゴリー２", "#", class: "sub-category"
                 = link_to "カテゴリー３", "#", class: "sub-category"
             %tr
               %th ブランド
               %td
-                = link_to "変数", "#"
+                -if @product.brand != nil
+                  = link_to "#{@product.brand.name}", "#"
             %tr
               %th 商品の状態
               %td
-                変数
+                = @product.status
             %tr
               %th 配送料の負担
               %td 
-                変数
+                = @delivery.responsibility
             %tr
               %th 配送の方法
               %td
-                変数
+                = @delivery.way
             %tr
               %th 配送元地域
               %td
-                = link_to "変数", "#" 
+                = link_to "#{@product.area}", "#" 
             %tr
               %th 発送日の目安
               %td
-                変数
+                = @product.sending_days
 
       .product-box-content__product-price-box
-        %span.product-price 値段変数
+        %span.product-price
+          ="¥#{@product.price.to_s(:delimited)}"
         %span.pruduct-tax  (税込)
-        %span.product-postage 送料変数
+        %span.product-postage
+          = @postage
 
       .product-box-content__buy-btn
         = link_to "購入画面に進む", "#"
 
       .product-box-content__product-information
         %p.product-box-content__product-information__text
-          商品の説明文
+          = @product.information
 
       .product-box-content__btn-box
         .product-box-content__btn-box__left
@@ -116,133 +111,41 @@
     .products-introduction
       .products-introduction__user
         %h2.product-box-head
-          = link_to "「出品者の名前」さんのその他の商品", "#", class: "product-box-head__link"
+          = link_to "#{@seller.nickname}さんのその他の商品", "#", class: "product-box-head__link"
         .product-introduction-box-content
-          .product-introduction-box-content__product-box
-            = link_to "#" do
-              %figure.product-box-photo
-                = image_tag "logo_white.svg"
-              .product-box-body
-                %h3.product-box-body__title 商品タイトルううううううううううううううううううう
-                .product-box-body__other
-                  .product-box-body__other__price 値段
-                  .product-box-body__other__like
-                    %span 数
-          .product-introduction-box-content__product-box
-            = link_to "#" do
-              %figure.product-box-photo
-                = image_tag "logo_white.svg"
-              .product-box-body
-                %h3.product-box-body__title 商品タイトルううううううううううううううううううう
-                .product-box-body__other
-                  .product-box-body__other__price 値段
-                  .product-box-body__other__like
-                    %span 数
-          .product-introduction-box-content__product-box
-            = link_to "#" do
-              %figure.product-box-photo
-                = image_tag "logo_white.svg"
-              .product-box-body
-                %h3.product-box-body__title 商品タイトルううううううううううううううううううう
-                .product-box-body__other
-                  .product-box-body__other__price 値段
-                  .product-box-body__other__like
-                    %span 数
-          .product-introduction-box-content__product-box
-            = link_to "#" do
-              %figure.product-box-photo
-                = image_tag "logo_white.svg"
-              .product-box-body
-                %h3.product-box-body__title 商品タイトルううううううううううううううううううう
-                .product-box-body__other
-                  .product-box-body__other__price 値段
-                  .product-box-body__other__like
-                    %span 数
-          .product-introduction-box-content__product-box
-            = link_to "#" do
-              %figure.product-box-photo
-                = image_tag "logo_white.svg"
-              .product-box-body
-                %h3.product-box-body__title 商品タイトルううううううううううううううううううう
-                .product-box-body__other
-                  .product-box-body__other__price 値段
-                  .product-box-body__other__like
-                    %span 数
-          .product-introduction-box-content__product-box
-            = link_to "#" do
-              %figure.product-box-photo
-                = image_tag "logo_white.svg"
-              .product-box-body
-                %h3.product-box-body__title 商品タイトルううううううううううううううううううう
-                .product-box-body__other
-                  .product-box-body__other__price 値段
-                  .product-box-body__other__like
-                    %span 数
+          - unless @seller_other_products == nil
+            -@seller_other_products.each do |product|
+              .product-introduction-box-content__product-box
+                = link_to product_path(product.id) do
+                  %figure.product-box-photo
+                    = image_tag("/uploads/image/image/#{product.images[0][:id]}/#{product.images[0][:image]}")
+                  .product-box-body
+                    %h3.product-box-body__title
+                      =product.name
+                    .product-box-body__other
+                      .product-box-body__other__price
+                        = "¥#{product.price.to_s(:delimited)}"
+                      .product-box-body__other__like
+                        %span 数
 
       .products-introduction__category
         %h2.product-box-head
-          = link_to "カテゴリー名　その他の商品", "#", class: "product-box-head__link"
+          = link_to "#{@category.name}その他の商品", "#", class: "product-box-head__link"
         .product-introduction-box-content
-          .product-introduction-box-content__product-box
-            = link_to "#" do
-              %figure.product-box-photo
-                = image_tag "logo_white.svg"
-              .product-box-body
-                %h3.product-box-body__title 商品タイトルううううううううううううううううううう
-                .product-box-body__other
-                  .product-box-body__other__price 値段
-                  .product-box-body__other__like
-                    %span 数
-          .product-introduction-box-content__product-box
-            = link_to "#" do
-              %figure.product-box-photo
-                = image_tag "logo_white.svg"
-              .product-box-body
-                %h3.product-box-body__title 商品タイトルううううううううううううううううううう
-                .product-box-body__other
-                  .product-box-body__other__price 値段
-                  .product-box-body__other__like
-                    %span 数
-          .product-introduction-box-content__product-box
-            = link_to "#" do
-              %figure.product-box-photo
-                = image_tag "logo_white.svg"
-              .product-box-body
-                %h3.product-box-body__title 商品タイトルううううううううううううううううううう
-                .product-box-body__other
-                  .product-box-body__other__price 値段
-                  .product-box-body__other__like
-                    %span 数
-          .product-introduction-box-content__product-box
-            = link_to "#" do
-              %figure.product-box-photo
-                = image_tag "logo_white.svg"
-              .product-box-body
-                %h3.product-box-body__title 商品タイトルううううううううううううううううううう
-                .product-box-body__other
-                  .product-box-body__other__price 値段
-                  .product-box-body__other__like
-                    %span 数
-          .product-introduction-box-content__product-box
-            = link_to "#" do
-              %figure.product-box-photo
-                = image_tag "logo_white.svg"
-              .product-box-body
-                %h3.product-box-body__title 商品タイトルううううううううううううううううううう
-                .product-box-body__other
-                  .product-box-body__other__price 値段
-                  .product-box-body__other__like
-                    %span 数
-          .product-introduction-box-content__product-box
-            = link_to "#" do
-              %figure.product-box-photo
-                = image_tag "logo_white.svg"
-              .product-box-body
-                %h3.product-box-body__title 商品タイトルううううううううううううううううううう
-                .product-box-body__other
-                  .product-box-body__other__price 値段
-                  .product-box-body__other__like
-                    %span 数
+          - unless @category_other_products == nil
+            -@category_other_products.each do |product|
+              .product-introduction-box-content__product-box
+                = link_to "#" do
+                  %figure.product-box-photo
+                    = image_tag("/uploads/image/image/#{product.images[0][:id]}/#{product.images[0][:image]}")
+                  .product-box-body
+                    %h3.product-box-body__title
+                      = product.name
+                    .product-box-body__other
+                      .product-box-body__other__price
+                        = "¥#{product.price.to_s(:delimited)}"
+                      .product-box-body__other__like
+                        %span 数
   
     %nav.bread-crumbs-bottom
       %ul

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -91,10 +91,12 @@
             = f.submit 'コメントする', class: "product-mesage-submit"
     
     %ul.product-link-list
-      %li.product-link-list__left
-        = link_to "前の商品", "#"
-      %li.product-link-list__right
-        = link_to "次の商品", "#"
+      -unless @back_product.name.blank?
+        %li.product-link-list__left
+          = link_to "#{@back_product.name}", "#"
+      -unless @next_product.name.blank?
+        %li.product-link-list__right
+          = link_to "#{@next_product.name}", "#"
 
     .product-media-box
       %ul.product-media-box__list
@@ -113,7 +115,7 @@
         %h2.product-box-head
           = link_to "#{@seller.nickname}さんのその他の商品", "#", class: "product-box-head__link"
         .product-introduction-box-content
-          - unless @seller_other_products == nil
+          - unless @seller_other_products.blank?
             -@seller_other_products.each do |product|
               .product-introduction-box-content__product-box
                 = link_to product_path(product.id) do
@@ -132,7 +134,7 @@
         %h2.product-box-head
           = link_to "#{@category.name}その他の商品", "#", class: "product-box-head__link"
         .product-introduction-box-content
-          - unless @category_other_products == nil
+          - unless @category_other_products.blank?
             -@category_other_products.each do |product|
               .product-introduction-box-content__product-box
                 = link_to "#" do


### PR DESCRIPTION
# What
商品詳細ページに商品データを表示できるようにした

# Why
商品の売買を行えるようにするため

<img width="1440" alt="product1" src="https://user-images.githubusercontent.com/56216409/69513038-d82d3900-0f89-11ea-8869-fc777a030897.jpg">
<img width="1440" alt="product2" src="https://user-images.githubusercontent.com/56216409/69513045-df544700-0f89-11ea-93cc-3ff61aee19f0.png">
<img width="1440" alt="product3" src="https://user-images.githubusercontent.com/56216409/69513070-f2ffad80-0f89-11ea-9d93-53ccd44755f0.jpg">
<img width="1440" alt="product4" src="https://user-images.githubusercontent.com/56216409/69513097-03178d00-0f8a-11ea-8ad4-78530a549e7e.jpg">