### PR TITLE
クレジットカードの登録・削除機能の実装（マイページ）

### DIFF
--- a/app/assets/javascripts/card.js
+++ b/app/assets/javascripts/card.js
@@ -1,0 +1,42 @@
+$(function(){
+
+  Payjp.setPublicKey('pk_test_34d7bf26ffb0a19c8c6ad2e1'); // payjp公開鍵
+
+  let form = $("#mypage-card-form");
+
+  $(form).on("click", "#mypage-token-submit", function(e){
+    e.preventDefault();
+    form.find("input[type=submit]").prop("disabled", true); // submitボタンを無効にし直接アプリに値が送られてくるのを防ぐ
+
+    // ユーザーが入力したデータからカードを作成
+    let card = {
+      number:     parseInt($("#mypage-card-number").val()), // 入力されたカード情報の文字列を整数に変換して取得
+      exp_month:  parseInt($("#mypage-exp-month").val()),
+      exp_year:   parseInt($("#mypage-exp-year").val()),
+      cvc:        parseInt($("#mypage-cvc").val())
+    };
+
+    // payjpサーバーと通信させ、トークンを作成
+    Payjp.createToken(card, function(status, response){
+
+      if (status == 200) {    // 通信に成功した場合
+
+        $("#mypage-card-number").removeAttr("name");
+        $("#mypage-exp-month").removeAttr("name");
+        $("#mypage-exp-year").removeAttr("name");
+        $("#mypage-cvc").removeAttr("name");          // DBに値が入らないように削除させる
+
+        let token = response.id;      // response.idでtokenのidが取れる
+        $(form).append($('<input type="hidden" name="payjp_token" class="payjp-token" />').val(token));
+          // コントローラにトークンIDを渡すためのinputタグを挿入。コントローラ側でparamsとして取得できる
+
+        $(form).get(0).submit();    // 初期化していたsubmitのイベントを実行させる
+
+      } else {    // payjpとの通信に失敗した場合
+
+        alert("カードの登録に失敗しました");
+
+      };
+    });
+  });
+})

--- a/app/assets/javascripts/card.js
+++ b/app/assets/javascripts/card.js
@@ -35,6 +35,7 @@ $(function(){
       } else {    // payjpとの通信に失敗した場合
 
         alert("カードの登録に失敗しました");
+        form.find("input[type=submit]").prop("disabled", false);  // ページを更新しなくても再度入力を行えるようにする
 
       };
     });

--- a/app/controllers/card_controller.rb
+++ b/app/controllers/card_controller.rb
@@ -1,10 +1,9 @@
 class CardController < ApplicationController
   include CardHelper
-  require 'dotenv'
 
   def new
     card = Card.where(user_id: current_user.id)
-    redirect_to card_mypage_path if card.nil?
+    redirect_to card_mypage_path unless card.blank?
   end
 
   def create

--- a/app/controllers/card_controller.rb
+++ b/app/controllers/card_controller.rb
@@ -1,10 +1,39 @@
 class CardController < ApplicationController
   include CardHelper
+  require 'dotenv'
 
   def new
+    card = Card.where(user_id: current_user.id)
+    redirect_to card_mypage_path if card.nil?
   end
 
   def create
+    Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+
+    unless params['payjp_token'].blank?
+
+      # payjp上でユーザーを作成。payjpにカード情報を登録
+      customer = Payjp::Customer.create(
+        card:  params['payjp_token']
+      )
+
+      # payjpから送られてくる情報を利用してcardテーブルのインスタンスを作成
+      @card = Card.new(
+        user_id:      current_user.id,
+        customer_id:  customer.id,
+        card_id:      customer.default_card
+      )
+
+      if @card.save
+        redirect_to card_mypage_path
+      else
+        redirect_to card_new_path
+      end
+
+    else
+      redirect_to card_new_path
+    end
+
   end
   
 end

--- a/app/controllers/card_controller.rb
+++ b/app/controllers/card_controller.rb
@@ -1,9 +1,9 @@
 class CardController < ApplicationController
   include CardHelper
+  before_action :set_card_data, only: [:new, :destroy]
 
   def new
-    card = Card.where(user_id: current_user.id)
-    redirect_to card_mypage_path unless card.blank?
+    redirect_to card_mypage_path unless @card.blank?
   end
 
   def create
@@ -36,16 +36,21 @@ class CardController < ApplicationController
   end
 
   def destroy
-    card = Card.find_by(user_id: current_user.id)
-    if card != nil
+    if @card != nil
       Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
-      customer = Payjp::Customer.retrieve(card.customer_id)
+      customer = Payjp::Customer.retrieve(@card.customer_id)
       customer.delete   # payjp側の情報を削除
-      card.destroy       # cardテーブルの情報を削除
+      @card.destroy       # cardテーブルの情報を削除
       redirect_to card_mypage_path
     else
       redirect_to card_mypage_path
     end
+  end
+
+  private
+
+  def set_card_data
+    @card = current_user.card
   end
   
 end

--- a/app/controllers/card_controller.rb
+++ b/app/controllers/card_controller.rb
@@ -34,5 +34,18 @@ class CardController < ApplicationController
     end
 
   end
+
+  def destroy
+    card = Card.find_by(user_id: current_user.id)
+    if card != nil
+      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+      customer = Payjp::Customer.retrieve(card.customer_id)
+      customer.delete   # payjp側の情報を削除
+      card.destroy       # cardテーブルの情報を削除
+      redirect_to card_mypage_path
+    else
+      redirect_to card_mypage_path
+    end
+  end
   
 end

--- a/app/controllers/card_controller.rb
+++ b/app/controllers/card_controller.rb
@@ -9,7 +9,7 @@ class CardController < ApplicationController
   def create
     Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
 
-    unless params['payjp_token'].blank?
+    unless params['payjp_token'].blank?   # jsにより、params['payjp_token']を受け取れる
 
       # payjp上でユーザーを作成。payjpにカード情報を登録
       customer = Payjp::Customer.create(

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -1,4 +1,6 @@
 class MypageController < ApplicationController
+  include MypageHelper
+
   def index
   end
 
@@ -9,6 +11,12 @@ class MypageController < ApplicationController
   # クレジットカード登録画面
   def card
     @card = Card.find_by(user_id: current_user.id)
+    
+    # payjpからカード情報を取り出す
+    Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+    customer = Payjp::Customer.retrieve(@card.customer_id)  # ユーザー情報の取得
+    @card_infomation = customer.cards.retrieve(@card.card_id) #ユーザーの情報からカードの情報を絞り込む
+    @card_icon = card_icon(@card_infomation)
   end
 
 end

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -10,7 +10,7 @@ class MypageController < ApplicationController
 
   # クレジットカード登録画面
   def card
-    @card = Card.find_by(user_id: current_user.id)
+    @card = current_user.card
     
     # payjpからカード情報を取り出す
     if @card != nil

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -13,10 +13,12 @@ class MypageController < ApplicationController
     @card = Card.find_by(user_id: current_user.id)
     
     # payjpからカード情報を取り出す
-    Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
-    customer = Payjp::Customer.retrieve(@card.customer_id)  # ユーザー情報の取得
-    @card_infomation = customer.cards.retrieve(@card.card_id) #ユーザーの情報からカードの情報を絞り込む
-    @card_icon = card_icon(@card_infomation)
+    if @card != nil
+      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+      customer = Payjp::Customer.retrieve(@card.customer_id)  # ユーザー情報の取得
+      @card_infomation = customer.cards.retrieve(@card.card_id) #ユーザーの情報からカードの情報を絞り込む
+      @card_icon = card_icon(@card_infomation)
+    end
   end
 
 end

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -17,7 +17,8 @@ class MypageController < ApplicationController
       Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
       customer = Payjp::Customer.retrieve(@card.customer_id)  # ユーザー情報の取得
       @card_infomation = customer.cards.retrieve(@card.card_id) #ユーザーの情報からカードの情報を絞り込む
-      @card_icon = card_icon(@card_infomation)
+
+      @card_icon = card_icon(@card_infomation)  # mypageヘルパーのメソッドの呼び出し
     end
   end
 

--- a/app/helpers/mypage_helper.rb
+++ b/app/helpers/mypage_helper.rb
@@ -1,20 +1,19 @@
 module MypageHelper
 
   def card_icon(card)
-    if card.brand == "Visa"
+    case card.brand
+    when "Visa"
       "logo_visa.gif"
-    elsif card.brand == "MasterCard"
+    when "MasterCard"
       "mc_vrt_pos.png"
-    elsif card.brand == "JCB"
+    when "JCB"
       "jcb-logomark-img-01.gif"
-    elsif card.brand == "American Express"
+    when "American Express"
       "amex-logomark-img-04.gif"
-    elsif card.brand == "Diners Club"
+    when "Diners Club"
       "diners-logomark-img-01.gif"
-    elsif card.brand == "Discover"
+    when "Discover"
       "discover-logomark-img.gif"
-    else
-      ""
     end
   end
 

--- a/app/helpers/mypage_helper.rb
+++ b/app/helpers/mypage_helper.rb
@@ -1,2 +1,21 @@
 module MypageHelper
+
+  def card_icon(card)
+    if card.brand == "Visa"
+      "logo_visa.gif"
+    elsif card.brand == "MasterCard"
+      "mc_vrt_pos.png"
+    elsif card.brand == "JCB"
+      "jcb-logomark-img-01.gif"
+    elsif card.brand == "American Express"
+      "amex-logomark-img-04.gif"
+    elsif card.brand == "Diners Club"
+      "diners-logomark-img-01.gif"
+    elsif card.brand == "Discover"
+      "discover-logomark-img.gif"
+    else
+      ""
+    end
+  end
+
 end

--- a/app/views/card/new.html.haml
+++ b/app/views/card/new.html.haml
@@ -6,12 +6,12 @@
     .main__right-content
       .main__right-content__user-info
         %h2 クレジットカード情報入力
-        = form_for "#", method: :post, html: { class: "user-form"} do |f|
+        = form_for :card, url: card_index_path, method: :post, html: { class: "user-form", id: "mypage-card-form"} do |f|
           .user-form__content
             .user-form__content__group
               %label カード番号
               %span.user-form__content__group--attention 必須
-              %input{placeholder: "半角数字のみ", class: "user-form__content__group__default"}
+              = f.text_field :number, placeholder: "半角数字のみ", maxlength: "16", id: "mypage-card-number", class: "user-form__content__group__default"
             .card-icon
               = image_tag "logo_visa.gif", width: '37', height: '25', alt: "visa"
               = image_tag "mc_vrt_pos.png", width: '37', height: '30', alt: "master"
@@ -27,7 +27,7 @@
                 .user-form__content__group__user-select__middle-box
                   .user-form__content__group__user-select__middle-box__month
                     %i.fa.fa-chevron-down
-                    %select.user-select-default
+                    = f.select :exp_month, "", {}, class: "user-select-default", id: "mypage-exp-month" do
                       %option{value: "01"} 01
                       %option{value: "02"} 02
                       %option{value: "03"} 03
@@ -44,7 +44,7 @@
                 .user-form__content__group__user-select__middle-box
                   .user-form__content__group__user-select__middle-box__year
                     %i.fa.fa-chevron-down
-                    %select.user-select-default
+                    = f.select :exp_year, "", {}, class: "user-select-default", id: "mypage-exp-year" do
                       - card_years.each do |year|
                         %option{value: year}
                           = year
@@ -52,12 +52,12 @@
             .user-form__content__group
               %label セキュリティコード
               %span.user-form__content__group--attention 必須
-              %input{placeholder: "カード背面の4桁もしくは3桁の番号", class: "user-form__content__group__default"}
+              = f.text_field :cvc, placeholder: "カード背面の4桁もしくは3桁の番号", maxlength: "4", class: "user-form__content__group__default", id: "mypage-cvc"
               %p.user-text.user-text-right
                 = link_to "#", method: :get do
                   %i.fa.fa-question-circle>
                   カード背面の番号とは？
-            =f.submit "次へ進む", class: "user-btn-default user-btn-red"
+            =f.submit "次へ進む", class: "user-btn-default user-btn-red", id: "mypage-token-submit"
 
 
-  -# = render partial: 'shared/footer'
+  = render partial: 'shared/footer'

--- a/app/views/mypage/card.html.haml
+++ b/app/views/mypage/card.html.haml
@@ -27,7 +27,7 @@
                 クレジットカード一覧
             %ul.payment-list
               %li
-                =form_for "#", html: {class: "mypage-card-content__box set-parent"} do |f|
+                =form_for :card, url: card_path(@card.id), method: :delete, html: {class: "mypage-card-content__box set-parent"} do |f|
                   = image_tag "#{@card_icon}", width: '40', height: '25', alt: "visa"
                   .setting-card-info
                     = "************#{@card_infomation.last4}"

--- a/app/views/mypage/card.html.haml
+++ b/app/views/mypage/card.html.haml
@@ -28,11 +28,11 @@
             %ul.payment-list
               %li
                 =form_for "#", html: {class: "mypage-card-content__box set-parent"} do |f|
-                  = image_tag "logo_visa.gif", width: '40', height: '25', alt: "visa"
+                  = image_tag "#{@card_icon}", width: '40', height: '25', alt: "visa"
                   .setting-card-info
-                    ************0000
+                    = "************#{@card_infomation.last4}"
                   .setting-card-info
-                    12 / 21
+                    = "#{@card_infomation.exp_month} / #{@card_infomation.exp_year}"
                   = f.submit "削除する", class: "card-delete-btn"
               .mypage-card-content__link-box
                 = link_to "#" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :card, only: [:create]
+  resources :card, only: [:create, :destroy]
   as :card do
     get 'mypage/card/create', to: 'card#new', as: :card_new
   end


### PR DESCRIPTION
# What
card.jsにユーザーが入力したカード情報をpayjpに送り、payjpからtokenを受け取るイベントを作成
mypageコントローラにカード情報を表示させるアクションを作成
cardコントローラにカード登録画面を表示させるアクション、カード作成・削除のアクションを作成
上記にて、　マイページ　→　支払い方法　画面からのクレジットカードの登録・削除機能を実装

ログイン時の登録機能、単体テスト、商品の購入機能は別ブランチにて実装します

# Why
新規登録後でもクレジットカードの情報を削除・登録できるようにするため

![setcard](https://user-images.githubusercontent.com/56216409/69603764-e1d4a080-105e-11ea-8fd3-a377453818e5.gif)