### PR TITLE
新規登録時のクレジットカード同時登録機能の実装

### DIFF
--- a/app/assets/javascripts/card.js
+++ b/app/assets/javascripts/card.js
@@ -2,18 +2,18 @@ $(function(){
 
   Payjp.setPublicKey('pk_test_34d7bf26ffb0a19c8c6ad2e1'); // payjp公開鍵
 
-  let form = $("#mypage-card-form");
+  let form = $("#card-form");
 
-  $(form).on("click", "#mypage-token-submit", function(e){
+  $(form).on("click", "#card-token-submit", function(e){
     e.preventDefault();
     form.find("input[type=submit]").prop("disabled", true); // submitボタンを無効にし直接アプリに値が送られてくるのを防ぐ
 
     // ユーザーが入力したデータからカードを作成
     let card = {
-      number:     parseInt($("#mypage-card-number").val()), // 入力されたカード情報の文字列を整数に変換して取得
-      exp_month:  parseInt($("#mypage-exp-month").val()),
-      exp_year:   parseInt($("#mypage-exp-year").val()),
-      cvc:        parseInt($("#mypage-cvc").val())
+      number:     parseInt($("#card-number").val()), // 入力されたカード情報の文字列を整数に変換して取得
+      exp_month:  parseInt($("#card-exp-month").val()),
+      exp_year:   parseInt($("#card-exp-year").val()),
+      cvc:        parseInt($("#card-cvc").val())
     };
 
     // payjpサーバーと通信させ、トークンを作成
@@ -21,10 +21,10 @@ $(function(){
 
       if (status == 200) {    // 通信に成功した場合
 
-        $("#mypage-card-number").removeAttr("name");
-        $("#mypage-exp-month").removeAttr("name");
-        $("#mypage-exp-year").removeAttr("name");
-        $("#mypage-cvc").removeAttr("name");          // DBに値が入らないように削除させる
+        $("#card-number").removeAttr("name");
+        $("#card-exp-month").removeAttr("name");
+        $("#card-exp-year").removeAttr("name");
+        $("#card-cvc").removeAttr("name");          // DBに値が入らないように削除させる
 
         let token = response.id;      // response.idでtokenのidが取れる
         $(form).append($('<input type="hidden" name="payjp_token" class="payjp-token" />').val(token));

--- a/app/assets/javascripts/card.js
+++ b/app/assets/javascripts/card.js
@@ -7,7 +7,6 @@ $(function(){
   $(form).on("click", "#card-token-submit", function(e){
     e.preventDefault();
     form.find("input[type=submit]").prop("disabled", true); // submitボタンを無効にし直接アプリに値が送られてくるのを防ぐ
-
     // ユーザーが入力したデータからカードを作成
     let card = {
       number:     parseInt($("#card-number").val()), // 入力されたカード情報の文字列を整数に変換して取得

--- a/app/assets/javascripts/signup.js
+++ b/app/assets/javascripts/signup.js
@@ -1,6 +1,5 @@
+// 生年月日取得
 $(function(){
-
-  // 生年月日取得
   $('.user-form__content__group__user-select').find('.user-select-default').change(function(){
     let year = $('#user-birthday-year').val();
     let month = $('#user-birthday-month').val();
@@ -8,5 +7,25 @@ $(function(){
     let birthday = year + month + day
     $('#user_birthday').val(birthday)
   });
+})
+
+// カード情報の取得
+$(function(){
+
+  Payjp.setPublicKey('pk_test_34d7bf26ffb0a19c8c6ad2e1'); // payjp公開鍵
+
+  let form = $("#signup-card-form");
+
+  $(form).on("click", "#signup-token-submit", function(e){
+    e.preventDefault();
+    form.find("input[type=submit]").prop("disabled", true);
+
+    let card = {
+      number:     parseInt($("#signup-card-number").val()), // 入力されたカード情報の文字列を整数に変換して取得
+      exp_month:  parseInt($("#signup-exp-month").val()),
+      exp_year:   parseInt($("#signup-exp-year").val()),
+      cvc:        parseInt($("#signup-cvc").val())
+    };
+  })
 
 })

--- a/app/assets/javascripts/signup.js
+++ b/app/assets/javascripts/signup.js
@@ -8,24 +8,3 @@ $(function(){
     $('#user_birthday').val(birthday)
   });
 })
-
-// カード情報の取得
-// $(function(){
-
-//   Payjp.setPublicKey('pk_test_34d7bf26ffb0a19c8c6ad2e1'); // payjp公開鍵
-
-//   let form = $("#signup-card-form");
-
-//   $(form).on("click", "#signup-token-submit", function(e){
-//     e.preventDefault();
-//     form.find("input[type=submit]").prop("disabled", true);
-
-//     let card = {
-//       number:     parseInt($("#signup-card-number").val()), // 入力されたカード情報の文字列を整数に変換して取得
-//       exp_month:  parseInt($("#signup-exp-month").val()),
-//       exp_year:   parseInt($("#signup-exp-year").val()),
-//       cvc:        parseInt($("#signup-cvc").val())
-//     };
-//   })
-
-// })

--- a/app/assets/javascripts/signup.js
+++ b/app/assets/javascripts/signup.js
@@ -10,22 +10,22 @@ $(function(){
 })
 
 // カード情報の取得
-$(function(){
+// $(function(){
 
-  Payjp.setPublicKey('pk_test_34d7bf26ffb0a19c8c6ad2e1'); // payjp公開鍵
+//   Payjp.setPublicKey('pk_test_34d7bf26ffb0a19c8c6ad2e1'); // payjp公開鍵
 
-  let form = $("#signup-card-form");
+//   let form = $("#signup-card-form");
 
-  $(form).on("click", "#signup-token-submit", function(e){
-    e.preventDefault();
-    form.find("input[type=submit]").prop("disabled", true);
+//   $(form).on("click", "#signup-token-submit", function(e){
+//     e.preventDefault();
+//     form.find("input[type=submit]").prop("disabled", true);
 
-    let card = {
-      number:     parseInt($("#signup-card-number").val()), // 入力されたカード情報の文字列を整数に変換して取得
-      exp_month:  parseInt($("#signup-exp-month").val()),
-      exp_year:   parseInt($("#signup-exp-year").val()),
-      cvc:        parseInt($("#signup-cvc").val())
-    };
-  })
+//     let card = {
+//       number:     parseInt($("#signup-card-number").val()), // 入力されたカード情報の文字列を整数に変換して取得
+//       exp_month:  parseInt($("#signup-exp-month").val()),
+//       exp_year:   parseInt($("#signup-exp-year").val()),
+//       cvc:        parseInt($("#signup-cvc").val())
+//     };
+//   })
 
-})
+// })

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -116,17 +116,15 @@ class SignupController < ApplicationController
     )
 
     if @user.save && session[:uid].blank?
-      # ログインするための情報を保管
-      session[:id] = @user.id
-      redirect_to done_signup_index_path
+      sign_in_and_redirect @user
     elsif @user.save && session[:uid]
-      session[:id] = @user.id
+      session[:user_id] = @user.id
       SnsCredential.create(
         uid:        session[:uid],
         provider:   session[:provider],
         user_id:    session[:id]
       )
-      redirect_to done_signup_index_path
+      sign_in_and_redirect @user
     else
       @status1 = "active"
       redirect_to controller: :signup, action: :registration
@@ -224,6 +222,11 @@ class SignupController < ApplicationController
       :nickname,
       :profile
     )
+  end
+
+  # 新規登録後ログインした状態で登録完了ページにアクセスさせるためのルート定義
+  def after_sign_in_path_for(resource)
+    done_signup_index_path
   end
 
 end

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -83,6 +83,8 @@ class SignupController < ApplicationController
     @status4 ="active"
 
     @user = User.new
+    @user.build_card
+
     #ここからアドレス
     addreses = user_params[:address_attributes]                             #変数に入れてる
     session[:ad_family_name] = addreses[:family_name]

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -1,111 +1,83 @@
 class SignupController < ApplicationController
+  include SignupHelper
+  before_action :set_user, only: [:registration, :sms_confirmation, :sms, :address, :credit_card]
 
   def index
   end
 
   def registration
-    @status1 ="active"
-    @years = []
-    Date.today.year.downto(1900){ |year|
-      @years << year
-    }
-    @days = []
-    for day in 1..31 do
-      if day.to_s.length == 1
-        @days << "0" + "#{day}"
-      else
-        @days << day
-      end
-    end
-    @user = User.new
+    status_bar("active", "", "", "", "")
+    
   end
 
   def sms_confirmation           #電話番号確認
-    @status1 ="through"
-    @status2 ="active"
+    status_bar("through", "active", "", "", "")
 
-    session[:uid] = user_params[:uid]
-    session[:provider] = user_params[:provider]
+    session[:uid]       = user_params[:uid]
+    session[:provider]  = user_params[:provider]
 
 
     if session[:uid].blank?
-      session[:nickname] = user_params[:nickname]
-      session[:email] = user_params[:email]
-      session[:password] = user_params[:password]
-      session[:family_name] = user_params[:family_name]
-      session[:first_name] = user_params[:first_name]
-      session[:family_name_cana] = user_params[:family_name_cana]
-      session[:first_name_cana] = user_params[:first_name_cana]
-      session[:birthday] = user_params[:birthday]
-      @user = User.new
+      session[:nickname]          = user_params[:nickname]
+      session[:email]             = user_params[:email]
+      session[:password]          = user_params[:password]
+      session[:family_name]       = user_params[:family_name]
+      session[:first_name]        = user_params[:first_name]
+      session[:family_name_cana]  = user_params[:family_name_cana]
+      session[:first_name_cana]   = user_params[:first_name_cana]
+      session[:birthday]          = user_params[:birthday]
     else
       # SNSでログインした際に、パスワードを自動で発行させる
-      number = [*0..9].sample(2)*''   # 数字を2つランダムで取り出す
-      alpha = [*'A'..'Z', *'a'..'z'].sample(5)*''   #アルファベットをランダムで5つ取り出す
-      password = (number + alpha).split("").shuffle.join    # 取り出した数字と英字をシャッフル
-      session[:nickname] = user_params[:nickname]
-      session[:email] = user_params[:email]
-      session[:password] = password
-      session[:family_name] = user_params[:family_name]
-      session[:first_name] = user_params[:first_name]
-      session[:family_name_cana] = user_params[:family_name_cana]
-      session[:first_name_cana] = user_params[:first_name_cana]
-      session[:birthday] = user_params[:birthday]
-      @user = User.new
+      number    = [*0..9].sample(2)*''   # 数字を2つランダムで取り出す
+      alpha     = [*'A'..'Z', *'a'..'z'].sample(5)*''   #アルファベットをランダムで5つ取り出す
+      password  = (number + alpha).split("").shuffle.join    # 取り出した数字と英字をシャッフル
+      session[:nickname]          = user_params[:nickname]
+      session[:email]             = user_params[:email]
+      session[:password]          = password
+      session[:family_name]       = user_params[:family_name]
+      session[:first_name]        = user_params[:first_name]
+      session[:family_name_cana]  = user_params[:family_name_cana]
+      session[:first_name_cana]   = user_params[:first_name_cana]
+      session[:birthday]          = user_params[:birthday]
     end
 
   end
 
   def sms
-    @status1 ="through"
-    @status2 ="active"
+    status_bar("through", "active", "", "", "")
 
     session[:telphone] = user_params[:telphone]
-
-    @user = User.new
   end
 
   def address
-    @status1 ="through"
-    @status2 ="through"
-    @status3 ="active"
+    status_bar("through", "through", "active", "", "")
 
-    @user = User.new
     @prefecture = User.set_prefecture
     @user.build_address
   end
 
   def credit_card
+    status_bar("through", "through", "through", "active", "")
 
-    @status1 ="through"
-    @status2 ="through"
-    @status3 ="through"
-    @status4 ="active"
-
-    @user = User.new
     @user.build_card
 
     #ここからアドレス
     addreses = user_params[:address_attributes]                             #変数に入れてる
-    session[:ad_family_name] = addreses[:family_name]
-    session[:ad_first_name] = addreses[:first_name]
+    session[:ad_family_name]      = addreses[:family_name]
+    session[:ad_first_name]       = addreses[:first_name]
     session[:ad_family_name_cana] = addreses[:family_name_cana]
-    session[:ad_first_name_cana] = addreses[:first_name_cana]
-    session[:postal_code] = addreses[:postal_code]
-    session[:prefecture] = addreses[:prefecture]
-    session[:city] = addreses[:city]
-    session[:address] = addreses[:address]
-    session[:building] = addreses[:building]
-    session[:tel] = addreses[:tel]
+    session[:ad_first_name_cana]  = addreses[:first_name_cana]
+    session[:postal_code]         = addreses[:postal_code]
+    session[:prefecture]          = addreses[:prefecture]
+    session[:city]                = addreses[:city]
+    session[:address]             = addreses[:address]
+    session[:building]            = addreses[:building]
+    session[:tel]                 = addreses[:tel]
     #ここまでアドレス
   end
 
   def done
-    @status1 ="through"
-    @status2 ="through"
-    @status3 ="through"
-    @status4 ="through"
-    @status5 ="active"
+    status_bar("through", "through", "through", "through", "active")
   end
 
   def create
@@ -133,6 +105,7 @@ class SignupController < ApplicationController
       building:         session[:building],
       tel:              session[:tel]
     )
+
     if @user.save && session[:uid].blank?
       # ログインするための情報を保管
       session[:id] = @user.id
@@ -173,6 +146,11 @@ class SignupController < ApplicationController
   end
 
   private
+
+  def set_user
+    @user = User.new
+  end
+
  # 許可するキーを設定します
   def user_params
 
@@ -187,7 +165,19 @@ class SignupController < ApplicationController
         :first_name_cana,
         :birthday,
         :telphone,
-        address_attributes: [:id, :family_name, :first_name, :family_name_cana, :first_name_cana, :postal_code, :prefecture, :city, :address, :building, :tel]
+        address_attributes:[
+          :id,
+          :family_name, 
+          :first_name, 
+          :family_name_cana, 
+          :first_name_cana, 
+          :postal_code, 
+          :prefecture, 
+          :city, 
+          :address, 
+          :building, 
+          :tel
+        ]
       )
     else
       params.require(:user).permit(
@@ -200,9 +190,20 @@ class SignupController < ApplicationController
         :first_name_cana,
         :birthday,
         :telphone,
-        address_attributes: [:id, :family_name, :first_name, :family_name_cana, :first_name_cana, :postal_code, :prefecture, :city, :address, :building, :tel]
+        address_attributes: [
+          :id, 
+          :family_name, 
+          :first_name, 
+          :family_name_cana, 
+          :first_name_cana, 
+          :postal_code, 
+          :prefecture, 
+          :city, 
+          :address, 
+          :building, 
+          :tel]
       ).merge(
-        uid: params[:user][:sns_credential][:uid],
+        uid:      params[:user][:sns_credential][:uid],
         provider: params[:user][:sns_credential][:provider]
       )
     end

--- a/app/helpers/signup_helper.rb
+++ b/app/helpers/signup_helper.rb
@@ -1,2 +1,31 @@
 module SignupHelper
+
+  def status_bar(status1, status2, status3, status4, status5)
+    @status1 = status1
+    @status2 = status2
+    @status3 = status3
+    @status4 = status4
+    @status5 = status5
+  end
+
+  def birthday_years
+    years = []
+    Date.today.year.downto(1900){ |year|
+      years << year
+    }
+    return years
+  end
+
+  def set_days
+    days = []
+    for day in 1..31 do
+      if day.to_s.length == 1
+        days << "0" + "#{day}"
+      else
+        days << day
+      end
+    end
+    return days
+  end
+  
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,7 @@ class User < ApplicationRecord
 
   accepts_nested_attributes_for :sns_credentials
   accepts_nested_attributes_for :address
+  accepts_nested_attributes_for :card
 
   def self.set_prefecture
     prefecture = ["北海道", "青森県", "岩手県","宮城県", "秋田県",

--- a/app/views/card/new.html.haml
+++ b/app/views/card/new.html.haml
@@ -6,12 +6,12 @@
     .main__right-content
       .main__right-content__user-info
         %h2 クレジットカード情報入力
-        = form_for :card, url: card_index_path, method: :post, html: { class: "user-form", id: "mypage-card-form"} do |f|
+        = form_for :card, url: card_index_path, method: :post, html: { class: "user-form", id: "card-form"} do |f|
           .user-form__content
             .user-form__content__group
               %label カード番号
               %span.user-form__content__group--attention 必須
-              = f.text_field :number, placeholder: "半角数字のみ", maxlength: "16", id: "mypage-card-number", class: "user-form__content__group__default"
+              = f.text_field :number, placeholder: "半角数字のみ", maxlength: "16", id: "card-number", class: "user-form__content__group__default"
             .card-icon
               = image_tag "logo_visa.gif", width: '37', height: '25', alt: "visa"
               = image_tag "mc_vrt_pos.png", width: '37', height: '30', alt: "master"
@@ -27,7 +27,7 @@
                 .user-form__content__group__user-select__middle-box
                   .user-form__content__group__user-select__middle-box__month
                     %i.fa.fa-chevron-down
-                    = f.select :exp_month, "", {}, class: "user-select-default", id: "mypage-exp-month" do
+                    = f.select :exp_month, "", {}, class: "user-select-default", id: "card-exp-month" do
                       %option{value: "01"} 01
                       %option{value: "02"} 02
                       %option{value: "03"} 03
@@ -44,7 +44,7 @@
                 .user-form__content__group__user-select__middle-box
                   .user-form__content__group__user-select__middle-box__year
                     %i.fa.fa-chevron-down
-                    = f.select :exp_year, "", {}, class: "user-select-default", id: "mypage-exp-year" do
+                    = f.select :exp_year, "", {}, class: "user-select-default", id: "card-exp-year" do
                       - card_years.each do |year|
                         %option{value: year}
                           = year
@@ -52,12 +52,12 @@
             .user-form__content__group
               %label セキュリティコード
               %span.user-form__content__group--attention 必須
-              = f.text_field :cvc, placeholder: "カード背面の4桁もしくは3桁の番号", maxlength: "4", class: "user-form__content__group__default", id: "mypage-cvc"
+              = f.text_field :cvc, placeholder: "カード背面の4桁もしくは3桁の番号", maxlength: "4", class: "user-form__content__group__default", id: "card-cvc"
               %p.user-text.user-text-right
                 = link_to "#", method: :get do
                   %i.fa.fa-question-circle>
                   カード背面の番号とは？
-            =f.submit "次へ進む", class: "user-btn-default user-btn-red", id: "mypage-token-submit"
+            =f.submit "次へ進む", class: "user-btn-default user-btn-red", id: "card-token-submit"
 
 
   = render partial: 'shared/footer'

--- a/app/views/main/index.html.haml
+++ b/app/views/main/index.html.haml
@@ -29,7 +29,7 @@
               %li.main__ladies__inner__list-item
                 = link_to '/', class: 'main__ladies__inner__list-item-a' do
                   = image_tag("#{image.image}/", class: 'main__ladies__inner__list-item-image')
-                  %p.main__ladies__inner__list-item-title #{@products[image.product_id-1].name}
+                  %p.main__ladies__inner__list-item-title #{image.product.name}
               - last_num = image.product_id-1
     %section.main__mens
       .main__mens__inner

--- a/app/views/signup/credit_card.html.haml
+++ b/app/views/signup/credit_card.html.haml
@@ -3,43 +3,44 @@
   .user-main
     .user-main__content
       %h2.user-title 支払い方法
-      = form_for @user, url: signup_index_path, method: :post, html: { class: "user-form"} do |f|
-        .user-form__content
-          .user-form__content__group
-            %label カード番号
-            %span.user-form__content__group--attention 必須
-            %input{placeholder: "半角数字のみ", class: "user-form__content__group__default"}
-          .card-icon
-            = image_tag "logo_visa.gif", width: '37', height: '25', alt: "visa"
-            = image_tag "mc_vrt_pos.png", width: '37', height: '30', alt: "master"
-            = image_tag "saison.jpg", width: '37', height: '25', alt: "saison"
-            = image_tag "jcb-logomark-img-01.gif", width: '37', height: '25', alt: "jcb"
-            = image_tag "amex-logomark-img-04.gif", width: '25', height: '25', alt: "amex"
-            = image_tag "diners-logomark-img-01.gif", width: '37', height: '25', alt: "diners"
-            = image_tag "discover-logomark-img.gif", width: '37', height: '25', alt: "discover"
-          .user-form__content__group
-            %label 有効期限
-            %span.user-form__content__group--attention 必須
-            .user-form__content__group__user-select
-              .user-form__content__group__user-select__middle-box
-                .user-form__content__group__user-select__middle-box__month
-                  %i.fa.fa-chevron-down
-                  %select.user-select-default
-                    %option 01
-                %span 月
-              .user-form__content__group__user-select__middle-box
-                .user-form__content__group__user-select__middle-box__year
-                  %i.fa.fa-chevron-down
-                  %select.user-select-default
-                    %option 19
-                %span 年
-          .user-form__content__group
-            %label セキュリティコード
-            %span.user-form__content__group--attention 必須
-            %input{placeholder: "カード背面の4桁もしくは3桁の番号", class: "user-form__content__group__default"}
-            %p.user-text.user-text-right
-              = link_to "#", method: :get do
-                %i.fa.fa-question-circle>
+      = form_for @user, url: signup_index_path, method: :post, html: { class: "user-form", id: "signup-card-form" } do |f|
+        = f.fields_for :card do |i|
+          .user-form__content
+            .user-form__content__group
+              %label カード番号
+              %span.user-form__content__group--attention 必須
+              = i.text_field :number, placeholder: "半角数字のみ", maxlength: "16", id: "signup-card-number", class: "user-form__content__group__default"
+            .card-icon
+              = image_tag "logo_visa.gif", width: '37', height: '25', alt: "visa"
+              = image_tag "mc_vrt_pos.png", width: '37', height: '30', alt: "master"
+              = image_tag "saison.jpg", width: '37', height: '25', alt: "saison"
+              = image_tag "jcb-logomark-img-01.gif", width: '37', height: '25', alt: "jcb"
+              = image_tag "amex-logomark-img-04.gif", width: '25', height: '25', alt: "amex"
+              = image_tag "diners-logomark-img-01.gif", width: '37', height: '25', alt: "diners"
+              = image_tag "discover-logomark-img.gif", width: '37', height: '25', alt: "discover"
+            .user-form__content__group
+              %label 有効期限
+              %span.user-form__content__group--attention 必須
+              .user-form__content__group__user-select
+                .user-form__content__group__user-select__middle-box
+                  .user-form__content__group__user-select__middle-box__month
+                    %i.fa.fa-chevron-down
+                    %select.user-select-default
+                      %option 01
+                  %span 月
+                .user-form__content__group__user-select__middle-box
+                  .user-form__content__group__user-select__middle-box__year
+                    %i.fa.fa-chevron-down
+                    %select.user-select-default
+                      %option 19
+                  %span 年
+            .user-form__content__group
+              %label セキュリティコード
+              %span.user-form__content__group--attention 必須
+              %input{placeholder: "カード背面の4桁もしくは3桁の番号", class: "user-form__content__group__default"}
+              %p.user-text.user-text-right
+                = link_to "#", method: :get do
+                  %i.fa.fa-question-circle>
                 カード背面の番号とは？
-          =f.submit "次へ進む", class: "user-btn-default user-btn-red"
+            =f.submit "次へ進む", class: "user-btn-default user-btn-red", id: "signup-token-submit"
   = render partial: 'shared/footer2'

--- a/app/views/signup/credit_card.html.haml
+++ b/app/views/signup/credit_card.html.haml
@@ -3,44 +3,57 @@
   .user-main
     .user-main__content
       %h2.user-title 支払い方法
-      = form_for @user, url: signup_index_path, method: :post, html: { class: "user-form", id: "signup-card-form" } do |f|
-        = f.fields_for :card do |i|
-          .user-form__content
-            .user-form__content__group
-              %label カード番号
-              %span.user-form__content__group--attention 必須
-              = i.text_field :number, placeholder: "半角数字のみ", maxlength: "16", id: "signup-card-number", class: "user-form__content__group__default"
-            .card-icon
-              = image_tag "logo_visa.gif", width: '37', height: '25', alt: "visa"
-              = image_tag "mc_vrt_pos.png", width: '37', height: '30', alt: "master"
-              = image_tag "saison.jpg", width: '37', height: '25', alt: "saison"
-              = image_tag "jcb-logomark-img-01.gif", width: '37', height: '25', alt: "jcb"
-              = image_tag "amex-logomark-img-04.gif", width: '25', height: '25', alt: "amex"
-              = image_tag "diners-logomark-img-01.gif", width: '37', height: '25', alt: "diners"
-              = image_tag "discover-logomark-img.gif", width: '37', height: '25', alt: "discover"
-            .user-form__content__group
-              %label 有効期限
-              %span.user-form__content__group--attention 必須
-              .user-form__content__group__user-select
-                .user-form__content__group__user-select__middle-box
-                  .user-form__content__group__user-select__middle-box__month
-                    %i.fa.fa-chevron-down
-                    %select.user-select-default
-                      %option 01
-                  %span 月
-                .user-form__content__group__user-select__middle-box
-                  .user-form__content__group__user-select__middle-box__year
-                    %i.fa.fa-chevron-down
-                    %select.user-select-default
-                      %option 19
-                  %span 年
-            .user-form__content__group
-              %label セキュリティコード
-              %span.user-form__content__group--attention 必須
-              %input{placeholder: "カード背面の4桁もしくは3桁の番号", class: "user-form__content__group__default"}
-              %p.user-text.user-text-right
-                = link_to "#", method: :get do
-                  %i.fa.fa-question-circle>
-                カード背面の番号とは？
-            =f.submit "次へ進む", class: "user-btn-default user-btn-red", id: "signup-token-submit"
+      = form_for @user, url: signup_index_path, method: :post, html: { class: "user-form", id: "card-form" } do |f|
+        -# = f.fields_for @card, html: {id: "card-form"} do |i|
+        .user-form__content
+          .user-form__content__group
+            %label カード番号
+            %span.user-form__content__group--attention 必須
+            = text_field_tag :number, "", placeholder: "半角数字のみ", maxlength: "16", id: "card-number", class: "user-form__content__group__default"
+          .card-icon
+            = image_tag "logo_visa.gif", width: '37', height: '25', alt: "visa"
+            = image_tag "mc_vrt_pos.png", width: '37', height: '30', alt: "master"
+            = image_tag "saison.jpg", width: '37', height: '25', alt: "saison"
+            = image_tag "jcb-logomark-img-01.gif", width: '37', height: '25', alt: "jcb"
+            = image_tag "amex-logomark-img-04.gif", width: '25', height: '25', alt: "amex"
+            = image_tag "diners-logomark-img-01.gif", width: '37', height: '25', alt: "diners"
+            = image_tag "discover-logomark-img.gif", width: '37', height: '25', alt: "discover"
+          .user-form__content__group
+            %label 有効期限
+            %span.user-form__content__group--attention 必須
+            .user-form__content__group__user-select
+              .user-form__content__group__user-select__middle-box
+                .user-form__content__group__user-select__middle-box__month
+                  %i.fa.fa-chevron-down
+                  %select.user-select-default#card-exp-month{name: "exp_month", type: "text"}
+                    %option{value: "01"} 01
+                    %option{value: "02"} 02
+                    %option{value: "03"} 03
+                    %option{value: "04"} 04
+                    %option{value: "05"} 05
+                    %option{value: "06"} 06
+                    %option{value: "07"} 07
+                    %option{value: "08"} 08
+                    %option{value: "09"} 09
+                    %option{value: 10} 10
+                    %option{value: 11} 11
+                    %option{value: 12} 12
+                %span 月
+              .user-form__content__group__user-select__middle-box
+                .user-form__content__group__user-select__middle-box__year
+                  %i.fa.fa-chevron-down
+                  %select.user-select-default#card-exp-year{name: "exp_year", type: "text"}
+                    - card_years.each do |year|
+                      %option{value: year}
+                        = year
+                %span 年
+          .user-form__content__group
+            %label セキュリティコード
+            %span.user-form__content__group--attention 必須
+            = text_field_tag :cvc, "", placeholder: "カード背面の4桁もしくは3桁の番号", maxlength: "4", class: "user-form__content__group__default", id: "card-cvc"
+            %p.user-text.user-text-right
+              = link_to "#", method: :get do
+                %i.fa.fa-question-circle>
+              カード背面の番号とは？
+          =f.submit "次へ進む", class: "user-btn-default user-btn-red", id: "card-token-submit"
   = render partial: 'shared/footer2'

--- a/app/views/signup/registration.html.haml
+++ b/app/views/signup/registration.html.haml
@@ -61,7 +61,7 @@
                     %i.fa.fa-chevron-down
                     %select.user-select-default#user-birthday-year
                       %option ---
-                      - @years.each do |year|
+                      - birthday_years.each do |year|
                         %option{value: year}
                           = year
                   %span 年
@@ -88,7 +88,7 @@
                     %i.fa.fa-chevron-down
                     %select.user-select-default#user-birthday-day
                       %option ---
-                      - @days.each do |day|
+                      - set_days.each do |day|
                         %option{value: day}
                           = day
                   %span 日


### PR DESCRIPTION
# What
カード単体登録で作成したcard.jsを使い回し、signupコントローラのcreateアクションにカード作成機能を追加することで、新規登録時にクレジットカードの登録も行えるようにした。
signupコントローラのリファクタリング
新規登録後、deviseの機能を通じてログイン状態を保持させるようにした

単体テスト、商品購入機能は別ブランチにて実装します

# Why
商品の購入を行うために必要なカード情報を、新規登録後にわざわざマイページから入力しなくても済むようにするため
新規登録後にログインする手間をなくすため

![signupcard](https://user-images.githubusercontent.com/56216409/69693159-d1343100-1117-11ea-95f6-5b5d656b5e2d.gif)
