### PR TITLE
ユーザー新規登録時、ページ毎にバリデーションチェックを行う

### DIFF
--- a/app/assets/stylesheets/_signup.scss
+++ b/app/assets/stylesheets/_signup.scss
@@ -381,3 +381,9 @@
     }
   }
 }
+
+.field_with_errors {
+  display: contents;
+  font-size: 14px;
+  color: red;
+}

--- a/app/assets/stylesheets/_signup.scss
+++ b/app/assets/stylesheets/_signup.scss
@@ -385,5 +385,12 @@
 .field_with_errors {
   display: contents;
   font-size: 14px;
+  input, select {
+    border: 1px solid red !important;
+  }
+}
+.error-message-box {
+  font-size: 14px;
   color: red;
+  padding-top: 5px;
 }

--- a/app/assets/stylesheets/_signup.scss
+++ b/app/assets/stylesheets/_signup.scss
@@ -390,7 +390,7 @@
   }
 }
 .error-message-box {
-  font-size: 14px;
+  font-size: 12px;
   color: red;
   padding-top: 5px;
 }

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -31,7 +31,7 @@ class SignupController < ApplicationController
       family_name_cana: user_params[:family_name_cana],
       first_name_cana:  user_params[:first_name_cana],
       birthday:         user_params[:birthday],
-      telphone:         "000000000000"
+      telphone:         "00000000000"
     )
 
     if @user.valid?

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -34,7 +34,7 @@ class SignupController < ApplicationController
       telphone:         "00000000000"
     )
 
-    if @user.valid?
+    if @user.valid?   # １ページ目のバリデーションチェック
       session[:nickname]          = user_params[:nickname]
       session[:email]             = user_params[:email]
       session[:password]          = session[:uid].blank? ? user_params[:password] : password
@@ -79,7 +79,7 @@ class SignupController < ApplicationController
       birthday:         session[:birthday],
       telphone:         user_params[:telphone]
     )
-    if @user.valid?
+    if @user.valid?   # 電話番号のバリデーションチェック
       session[:telphone] = user_params[:telphone]
     else
       status_bar("through", "active", "", "", "")
@@ -97,8 +97,8 @@ class SignupController < ApplicationController
   def credit_card
     status_bar("through", "through", "through", "active", "")
     
-    #ここからアドレス
-    addresses = user_params[:address_attributes]   
+    addresses = user_params[:address_attributes]   # addressのみのparamsを取得し変数に格納
+    # 発送元住所のバリデーションチェックのためにインスタンスを生成
     @address = @user.build_address(
       family_name:      addresses[:family_name],
       first_name:       addresses[:first_name],
@@ -111,7 +111,7 @@ class SignupController < ApplicationController
       building:         addresses[:building],
       tel:              addresses[:tel]
     )
-    if @address.valid?
+    if @address.valid?    # 発送元住所のバリデーションチェック
       session[:ad_family_name]      = addresses[:family_name]
       session[:ad_first_name]       = addresses[:first_name]
       session[:ad_family_name_cana] = addresses[:family_name_cana]
@@ -128,7 +128,6 @@ class SignupController < ApplicationController
       render address_signup_index_path
     end
 
-    #ここまでアドレス
   end
 
   def done
@@ -185,10 +184,6 @@ class SignupController < ApplicationController
       redirect_to controller: :signup, action: :registration
     end
 
-  end
-
-  # ユーザー情報確認ページ addressコントローラマージされたらそっちに移す
-  def edit
   end
 
   # ユーザープロフィールページ

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -1,6 +1,6 @@
 class SignupController < ApplicationController
   include SignupHelper, CardHelper
-  before_action :set_user, only: [:registration, :sms_confirmation, :sms, :address, :credit_card]
+  before_action :set_user, only: [:registration, :address, :credit_card]
 
   def index
   end

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -91,7 +91,7 @@ class SignupController < ApplicationController
     status_bar("through", "through", "active", "", "")
 
     @prefecture = User.set_prefecture
-    @user.build_address
+    @address = @user.build_address
   end
 
   def credit_card
@@ -99,7 +99,7 @@ class SignupController < ApplicationController
     
     #ここからアドレス
     addresses = user_params[:address_attributes]   
-    address = @user.build_address(
+    @address = @user.build_address(
       family_name:      addresses[:family_name],
       first_name:       addresses[:first_name],
       family_name_cana: addresses[:family_name_cana],
@@ -111,7 +111,7 @@ class SignupController < ApplicationController
       building:         addresses[:building],
       tel:              addresses[:tel]
     )
-    if address.valid?
+    if @address.valid?
       session[:ad_family_name]      = addresses[:family_name]
       session[:ad_first_name]       = addresses[:first_name]
       session[:ad_family_name_cana] = addresses[:family_name_cana]

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,15 +1,21 @@
 class Address < ApplicationRecord
   
+  VALID_NAME_CANA = /\A[\p{katakana}　ー－&&[^ -~｡-ﾟ]]+\z/
+  VALID_POSTAL_CODE = /\A\d{3}[-]\d{4}\z/
+
   validates :family_name, presence: true
   validates :first_name, presence: true
-  validates :family_name_cana, presence: true
-  validates :first_name_cana, presence: true
-  validates :postal_code, presence: true
+  validates :family_name_cana, presence: true, format: { with: VALID_NAME_CANA, message: 'は全角カタカナのみで入力してください' }
+  validates :first_name_cana, presence: true, format: { with: VALID_NAME_CANA, message: 'は全角カタカナのみで入力してください' }
+  validates :postal_code, presence: true, format: { with: VALID_POSTAL_CODE, message: 'はハイフンを含めた7桁の数字を入力してください' }
   validates :prefecture, presence: true
   validates :city, presence: true
   validates :address, presence: true
 
   belongs_to :user
+
+
+
 
   def self.set_prefecture
     prefecture = ["北海道", "青森県", "岩手県","宮城県", "秋田県",

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,13 +1,13 @@
 class Address < ApplicationRecord
   
-  # validates :family_name, presence: true
-  # validates :first_name, presence: true
-  # validates :family_name_cana, presence: true
-  # validates :first_name_cana, presence: true
-  # validates :postal_code, presence: true
-  # validates :prefecture, presence: true
-  # validates :city, presence: true
-  # validates :address, presence: true
+  validates :family_name, presence: true
+  validates :first_name, presence: true
+  validates :family_name_cana, presence: true
+  validates :first_name_cana, presence: true
+  validates :postal_code, presence: true
+  validates :prefecture, presence: true
+  validates :city, presence: true
+  validates :address, presence: true
 
   belongs_to :user
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,16 +8,17 @@ class User < ApplicationRecord
 
   VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i
   VALID_NAME_CANA = /\A[\p{katakana}　ー－&&[^ -~｡-ﾟ]]+\z/
+  VALID_PHONE_REGEX = /\A\d{10}$|^\d{11}\z/
 
   validates :nickname, presence: true
   validates :email, presence: true
-  validates :password, format: { with: VALID_PASSWORD_REGEX }, on: :create
+  validates :password, format: { with: VALID_PASSWORD_REGEX, message: 'は英字と数字の両方を含んだ7文字以上で入力してください' }, on: :create
   validates :family_name, presence: true
   validates :first_name, presence: true
-  validates :family_name_cana, presence: true, format: { with: VALID_NAME_CANA }
-  validates :first_name_cana, presence: true, format: { with: VALID_NAME_CANA }
+  validates :family_name_cana, presence: true, format: { with: VALID_NAME_CANA, message: 'は全角カタカナのみで入力してください' }
+  validates :first_name_cana, presence: true, format: { with: VALID_NAME_CANA, message: 'は全角カタカナのみで入力してください' }
   validates :birthday, presence: true
-  validates :telphone, presence: true
+  validates :telphone, presence: true, format: { with: VALID_PHONE_REGEX, message: 'はハイフンを除いた10桁か11桁の数字を入力してください' }
 
   has_many :sns_credentials, dependent: :destroy
   has_many :payments

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,9 +9,10 @@ class User < ApplicationRecord
   VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i
   VALID_NAME_CANA = /\A[\p{katakana}　ー－&&[^ -~｡-ﾟ]]+\z/
   VALID_PHONE_REGEX = /\A\d{10}$|^\d{11}\z/
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
 
   validates :nickname, presence: true
-  validates :email, presence: true
+  validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX, message: 'は有効なものを入力してください' }
   validates :password, format: { with: VALID_PASSWORD_REGEX, message: 'は英字と数字の両方を含んだ7文字以上で入力してください' }, on: :create
   validates :family_name, presence: true
   validates :first_name, presence: true

--- a/app/views/signup/address.html.haml
+++ b/app/views/signup/address.html.haml
@@ -14,11 +14,13 @@
                 .error-message-box
                   - @address.errors[:family_name].each do |error|
                     = "姓#{error}"
+                    %br
               =a.text_field :first_name, placeholder: "例) 綾", class: "user-form__content__group__default"
               -if @address.errors[:first_name][0] != nil
                 .error-message-box
                   - @address.errors[:first_name].each do |error|
                     = "名#{error}"
+                    %br
 
             .user-form__content__group
               %label お名前カナ
@@ -28,11 +30,13 @@
                 .error-message-box
                   - @address.errors[:family_name_cana].each do |error|
                     = "姓（カナ）#{error}"
+                    %br
               =a.text_field :first_name_cana, placeholder: "例) アヤ", class: "user-form__content__group__default"
               -if @address.errors[:first_name_cana][0] != nil
                 .error-message-box
                   - @address.errors[:first_name_cana].each do |error|
                     = "名（カナ）#{error}"
+                    %br
 
             .user-form__content__group
               %label 郵便番号
@@ -42,6 +46,7 @@
                 .error-message-box
                   - @address.errors[:postal_code].each do |error|
                     = "郵便番号#{error}"
+                    %br
 
             .user-form__content__group
               %label 都道府県
@@ -55,6 +60,7 @@
               .error-message-box
                 - @address.errors[:prefecture].each do |error|
                   = "都道府県#{error}"
+                  %br
 
             .user-form__content__group
               %label 市区町村
@@ -64,6 +70,7 @@
                 .error-message-box
                   - @address.errors[:city].each do |error|
                     = "市区町村#{error}"
+                    %br
 
             .user-form__content__group
               %label 番地
@@ -73,25 +80,17 @@
                 .error-message-box
                   - @address.errors[:address].each do |error|
                     = "番地#{error}"
+                    %br
 
             .user-form__content__group
               %label 建物名
               %span.user-form__content__group--optional 任意
               =a.text_field :building, placeholder: "例) 柳ビル103", class: "user-form__content__group__default"
-              -if @address.errors[:building][0] != nil
-                .error-message-box
-                  - @address.errors[:building].each do |error|
-                    = "建物名#{error}"
-
 
             .user-form__content__group
               %label 電話
               %span.user-form__content__group--optional 任意
               =a.text_field :tel, placeholder: "例) 09012345678", class: "user-form__content__group__default"
-              -if @address.errors[:tel][0] != nil
-                .error-message-box
-                  - @address.errors[:tel].each do |error|
-                    = "電話番号#{error}"
 
             =f.submit "次へ進む", class: "user-btn-default user-btn-red"
   =render partial: 'shared/footer2'

--- a/app/views/signup/address.html.haml
+++ b/app/views/signup/address.html.haml
@@ -10,16 +10,39 @@
               %label お名前
               %span.user-form__content__group--attention 必須
               =a.text_field :family_name, placeholder: "例) 山田", class: "user-form__content__group__default"
+              -if @address.errors[:family_name][0] != nil
+                .error-message-box
+                  - @address.errors[:family_name].each do |error|
+                    = error
               =a.text_field :first_name, placeholder: "例) 綾", class: "user-form__content__group__default"
+              -if @address.errors[:first_name][0] != nil
+                .error-message-box
+                  - @address.errors[:first_name].each do |error|
+                    = error
+
             .user-form__content__group
               %label お名前カナ
               %span.user-form__content__group--attention 必須
               =a.text_field :family_name_cana, placeholder: "例) ヤマダ", class: "user-form__content__group__default"
+              -if @address.errors[:family_name_cana][0] != nil
+                .error-message-box
+                  - @address.errors[:family_name_cana].each do |error|
+                    = error
               =a.text_field :first_name_cana, placeholder: "例) アヤ", class: "user-form__content__group__default"
+              -if @address.errors[:first_name_cana][0] != nil
+                .error-message-box
+                  - @address.errors[:first_name_cana].each do |error|
+                    = error
+
             .user-form__content__group
               %label 郵便番号
               %span.user-form__content__group--attention 必須
               =a.text_field :postal_code, placeholder: "例) 123-4567", class: "user-form__content__group__default"
+              -if @address.errors[:postal_code][0] != nil
+                .error-message-box
+                  - @address.errors[:postal_code].each do |error|
+                    = error
+
             .user-form__content__group
               %label 都道府県
               %span.user-form__content__group--attention 必須
@@ -28,21 +51,47 @@
                   %i.fa.fa-chevron-down
                   = a.select :prefecture, @prefecture, {}, class: "user-select-default"
             =a.text_field :prefecture, autocomplete: "prefecture", type: "hidden", value: "北海道"
+            -if @address.errors[:prefecture][0] != nil
+              .error-message-box
+                - @address.errors[:prefecture].each do |error|
+                  = error
+
             .user-form__content__group
               %label 市区町村
               %span.user-form__content__group--attention 必須
               =a.text_field :city, placeholder: "例) 横浜市緑区", class: "user-form__content__group__default"
+              -if @address.errors[:city][0] != nil
+                .error-message-box
+                  - @address.errors[:city].each do |error|
+                    = error
+
             .user-form__content__group
               %label 番地
               %span.user-form__content__group--attention 必須
               =a.text_field :address, placeholder: "例) 青山1-1-1", class: "user-form__content__group__default"
+              -if @address.errors[:address][0] != nil
+                .error-message-box
+                  - @address.errors[:address].each do |error|
+                    = error
+
             .user-form__content__group
               %label 建物名
               %span.user-form__content__group--optional 任意
               =a.text_field :building, placeholder: "例) 柳ビル103", class: "user-form__content__group__default"
+              -if @address.errors[:building][0] != nil
+                .error-message-box
+                  - @address.errors[:building].each do |error|
+                    = error
+
+
             .user-form__content__group
               %label 電話
               %span.user-form__content__group--optional 任意
               =a.text_field :tel, placeholder: "例) 09012345678", class: "user-form__content__group__default"
+              -if @address.errors[:tel][0] != nil
+                .error-message-box
+                  - @address.errors[:tel].each do |error|
+                    = error
+
             =f.submit "次へ進む", class: "user-btn-default user-btn-red"
   =render partial: 'shared/footer2'

--- a/app/views/signup/address.html.haml
+++ b/app/views/signup/address.html.haml
@@ -13,12 +13,12 @@
               -if @address.errors[:family_name][0] != nil
                 .error-message-box
                   - @address.errors[:family_name].each do |error|
-                    = error
+                    = "姓#{error}"
               =a.text_field :first_name, placeholder: "例) 綾", class: "user-form__content__group__default"
               -if @address.errors[:first_name][0] != nil
                 .error-message-box
                   - @address.errors[:first_name].each do |error|
-                    = error
+                    = "名#{error}"
 
             .user-form__content__group
               %label お名前カナ
@@ -27,12 +27,12 @@
               -if @address.errors[:family_name_cana][0] != nil
                 .error-message-box
                   - @address.errors[:family_name_cana].each do |error|
-                    = error
+                    = "姓（カナ）#{error}"
               =a.text_field :first_name_cana, placeholder: "例) アヤ", class: "user-form__content__group__default"
               -if @address.errors[:first_name_cana][0] != nil
                 .error-message-box
                   - @address.errors[:first_name_cana].each do |error|
-                    = error
+                    = "名（カナ）#{error}"
 
             .user-form__content__group
               %label 郵便番号
@@ -41,7 +41,7 @@
               -if @address.errors[:postal_code][0] != nil
                 .error-message-box
                   - @address.errors[:postal_code].each do |error|
-                    = error
+                    = "郵便番号#{error}"
 
             .user-form__content__group
               %label 都道府県
@@ -54,7 +54,7 @@
             -if @address.errors[:prefecture][0] != nil
               .error-message-box
                 - @address.errors[:prefecture].each do |error|
-                  = error
+                  = "都道府県#{error}"
 
             .user-form__content__group
               %label 市区町村
@@ -63,7 +63,7 @@
               -if @address.errors[:city][0] != nil
                 .error-message-box
                   - @address.errors[:city].each do |error|
-                    = error
+                    = "市区町村#{error}"
 
             .user-form__content__group
               %label 番地
@@ -72,7 +72,7 @@
               -if @address.errors[:address][0] != nil
                 .error-message-box
                   - @address.errors[:address].each do |error|
-                    = error
+                    = "番地#{error}"
 
             .user-form__content__group
               %label 建物名
@@ -81,7 +81,7 @@
               -if @address.errors[:building][0] != nil
                 .error-message-box
                   - @address.errors[:building].each do |error|
-                    = error
+                    = "建物名#{error}"
 
 
             .user-form__content__group
@@ -91,7 +91,7 @@
               -if @address.errors[:tel][0] != nil
                 .error-message-box
                   - @address.errors[:tel].each do |error|
-                    = error
+                    = "電話番号#{error}"
 
             =f.submit "次へ進む", class: "user-btn-default user-btn-red"
   =render partial: 'shared/footer2'

--- a/app/views/signup/registration.html.haml
+++ b/app/views/signup/registration.html.haml
@@ -55,14 +55,19 @@
             .form-half
               =f.text_field :family_name, autocomplete: "family_name", placeholder: "例) 山田", class: "user-form__content__group__default half"
               =f.text_field :first_name, autocomplete: "first_name", placeholder: "例) 彩", class: "user-form__content__group__default half"
-            -if @user.errors[:family_name][0] != nil
+            -if @user.errors[:family_name][0] != nil || @user.errors[:first_name][0] != nil
               .error-message-box
-                - @user.errors[:family_name].each do |error|
-                  = error
-            -if @user.errors[:first_name][0] != nil
-              .error-message-box
-                - @user.errors[:first_name].each do |error|
-                  = error
+                - if @user.errors[:family_name][0] != nil && @user.errors[:first_name][0] != nil
+                  - @user.errors[:family_name].each do |error|
+                    = error
+                  - @user.errors[:first_name].each do |error|
+                    = error
+                -elsif @user.errors[:first_name][0] != nil
+                  - @user.errors[:first_name].each do |error|
+                    = error
+                -else
+                  - @user.errors[:family_name].each do |error|
+                    = error
 
           .user-form__content__group
             %label お名前カナ(全角)
@@ -70,14 +75,19 @@
             .form-half
               =f.text_field :family_name_cana, autocomplete: "family_name_cana", placeholder: "例) ヤマダ", class: "user-form__content__group__default half"
               =f.text_field :first_name_cana, autocomplete: "first_name_cana", placeholder: "例) アヤ", class: "user-form__content__group__default half"
-            -if @user.errors[:family_name_cana][0] != nil
+            -if @user.errors[:family_name_cana][0] != nil || @user.errors[:first_name_cana][0] != nil
               .error-message-box
-                - @user.errors[:family_name_cana].each do |error|
-                  = error
-            -if @user.errors[:first_name_cana][0] != nil
-              .error-message-box
-                - @user.errors[:first_name_cana].each do |error|
-                  = error
+                - if @user.errors[:family_name_cana][0] != nil && @user.errors[:first_name_cana][0] != nil
+                  - @user.errors[:family_name_cana].each do |error|
+                    = error
+                  - @user.errors[:first_name_cana].each do |error|
+                    = error
+                -elsif @user.errors[:first_name_cana][0] != nil
+                  - @user.errors[:first_name_cana].each do |error|
+                    = error
+                -else
+                  - @user.errors[:family_name_cana].each do |error|
+                    = error
 
           .user-form__content__group
             %label 生年月日

--- a/app/views/signup/registration.html.haml
+++ b/app/views/signup/registration.html.haml
@@ -13,17 +13,29 @@
             %label ニックネーム
             %span.user-form__content__group--attention 必須
             =f.text_field :nickname, autofocus: true, autocomplete: "nickname", placeholder: "例)フリマケ太郎", class: "user-form__content__group__default"
+            -if @user.errors[:nickname][0] != nil
+              .error-message-box
+                - @user.errors[:nickname].each do |error|
+                  = error
 
           .user-form__content__group
             %label メールアドレス
             %span.user-form__content__group--attention 必須
             =f.email_field :email, autocomplete: "email", placeholder: "PC・携帯どちらでも可", class: "user-form__content__group__default"
+            -if @user.errors[:email][0] != nil
+              .error-message-box
+                - @user.errors[:email].each do |error|
+                  = error
 
           - unless @sns.present?
             .user-form__content__group.user-form__content__password
               %label パスワード
               %span.user-form__content__group--attention 必須
               =f.password_field :password, autocomplete: "password", placeholder: "7文字以上", class: "user-form__content__group__default"
+              -if @user.errors[:password][0] != nil
+                .error-message-box
+                  - @user.errors[:password].each do |error|
+                    = error
               .user-form__content__password__check
                 .checkbox-default
                   %input
@@ -43,6 +55,14 @@
             .form-half
               =f.text_field :family_name, autocomplete: "family_name", placeholder: "例) 山田", class: "user-form__content__group__default half"
               =f.text_field :first_name, autocomplete: "first_name", placeholder: "例) 彩", class: "user-form__content__group__default half"
+            -if @user.errors[:family_name][0] != nil
+              .error-message-box
+                - @user.errors[:family_name].each do |error|
+                  = error
+            -if @user.errors[:first_name][0] != nil
+              .error-message-box
+                - @user.errors[:first_name].each do |error|
+                  = error
 
           .user-form__content__group
             %label お名前カナ(全角)
@@ -50,6 +70,14 @@
             .form-half
               =f.text_field :family_name_cana, autocomplete: "family_name_cana", placeholder: "例) ヤマダ", class: "user-form__content__group__default half"
               =f.text_field :first_name_cana, autocomplete: "first_name_cana", placeholder: "例) アヤ", class: "user-form__content__group__default half"
+            -if @user.errors[:family_name_cana][0] != nil
+              .error-message-box
+                - @user.errors[:family_name_cana].each do |error|
+                  = error
+            -if @user.errors[:first_name_cana][0] != nil
+              .error-message-box
+                - @user.errors[:first_name_cana].each do |error|
+                  = error
 
           .user-form__content__group
             %label 生年月日
@@ -93,6 +121,11 @@
                           = day
                   %span 日
               =f.text_field :birthday, autocomplete: "birthday", type: "hidden", value: "", class: "user-birthday-data"
+              -if @user.errors[:birthday][0] != nil
+                .error-message-box
+                  - @user.errors[:birthday].each do |error|
+                    = error
+
               %p.user-form-info
                 ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
           .user-form__content__group

--- a/app/views/signup/registration.html.haml
+++ b/app/views/signup/registration.html.haml
@@ -16,7 +16,8 @@
             -if @user.errors[:nickname][0] != nil
               .error-message-box
                 - @user.errors[:nickname].each do |error|
-                  = error
+                  = "ニックネーム#{error}" 
+                  %br
 
           .user-form__content__group
             %label メールアドレス
@@ -25,17 +26,19 @@
             -if @user.errors[:email][0] != nil
               .error-message-box
                 - @user.errors[:email].each do |error|
-                  = error
+                  = "メールアドレス#{error}" 
+                  %br
 
           - unless @sns.present?
             .user-form__content__group.user-form__content__password
               %label パスワード
               %span.user-form__content__group--attention 必須
-              =f.password_field :password, autocomplete: "password", placeholder: "7文字以上", class: "user-form__content__group__default"
+              =f.password_field :password, autocomplete: "password", placeholder: "7文字以上の半角英数字", class: "user-form__content__group__default"
               -if @user.errors[:password][0] != nil
                 .error-message-box
                   - @user.errors[:password].each do |error|
-                    = error
+                    = "パスワード#{error}"
+                    %br
               .user-form__content__password__check
                 .checkbox-default
                   %input
@@ -59,15 +62,19 @@
               .error-message-box
                 - if @user.errors[:family_name][0] != nil && @user.errors[:first_name][0] != nil
                   - @user.errors[:family_name].each do |error|
-                    = error
+                    = "姓#{error}"
+                    %br
                   - @user.errors[:first_name].each do |error|
-                    = error
+                    = "名#{error}"
+                    %br
                 -elsif @user.errors[:first_name][0] != nil
                   - @user.errors[:first_name].each do |error|
-                    = error
+                    = "名#{error}"
+                    %br
                 -else
                   - @user.errors[:family_name].each do |error|
-                    = error
+                    = "姓#{error}"
+                    %br
 
           .user-form__content__group
             %label お名前カナ(全角)
@@ -79,15 +86,19 @@
               .error-message-box
                 - if @user.errors[:family_name_cana][0] != nil && @user.errors[:first_name_cana][0] != nil
                   - @user.errors[:family_name_cana].each do |error|
-                    = error
+                    = "姓（カナ）#{error}"
+                    %br
                   - @user.errors[:first_name_cana].each do |error|
-                    = error
+                    = "名（カナ）#{error}"
+                    %br
                 -elsif @user.errors[:first_name_cana][0] != nil
                   - @user.errors[:first_name_cana].each do |error|
-                    = error
+                    = "名（カナ）#{error}"
+                    %br
                 -else
                   - @user.errors[:family_name_cana].each do |error|
-                    = error
+                    = "姓（カナ）#{error}"
+                    %br
 
           .user-form__content__group
             %label 生年月日
@@ -134,7 +145,8 @@
               -if @user.errors[:birthday][0] != nil
                 .error-message-box
                   - @user.errors[:birthday].each do |error|
-                    = error
+                    = "生年月日#{error}"
+                    %br
 
               %p.user-form-info
                 ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。

--- a/app/views/signup/sms_confirmation.html.haml
+++ b/app/views/signup/sms_confirmation.html.haml
@@ -11,7 +11,8 @@
             -if @user.errors[:telphone][0] != nil
               .error-message-box
                 - @user.errors[:telphone].each do |error|
-                  = error
+                  = "電話番号#{error}"
+                  %br
 
           %p.user-text 本人確認のため、電話番号のSMS(ショートサービス)を利用して認証を行います。
           =f.submit "SMSを送信する", class: "user-btn-default user-btn-red"

--- a/app/views/signup/sms_confirmation.html.haml
+++ b/app/views/signup/sms_confirmation.html.haml
@@ -8,6 +8,11 @@
           .user-form__content__group
             %label 電話番号の確認
             =f.text_field :telphone, placeholder: "携帯電話の番号を入力", class: "user-form__content__group__default"
+            -if @user.errors[:telphone][0] != nil
+              .error-message-box
+                - @user.errors[:telphone].each do |error|
+                  = error
+
           %p.user-text 本人確認のため、電話番号のSMS(ショートサービス)を利用して認証を行います。
           =f.submit "SMSを送信する", class: "user-btn-default user-btn-red"
           %p.user-text ※電話番号は本人確認や不正利用防止のために利用します。他のユーザーに公開されることはありません。

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,7 @@ module FreemarketSample62f
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
-
+    config.i18n.default_locale = :ja
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,207 @@
+---
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: 受諾してください
+      blank: 入力してください
+      confirmation: "%{attribute}の入力が一致しません"
+      empty: 入力してください
+      equal_to: "%{count}にしてください"
+      even: 偶数にしてください
+      exclusion: 予約されています
+      greater_than: "%{count}より大きい値にしてください"
+      greater_than_or_equal_to: "%{count}以上の値にしてください"
+      inclusion: 一覧にありません
+      invalid: 不正な値です
+      less_than: "%{count}より小さい値にしてください"
+      less_than_or_equal_to: "%{count}以下の値にしてください"
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: 数値で入力してください
+      not_an_integer: 整数で入力してください
+      odd: 奇数にしてください
+      other_than: "%{count}以外の値にしてください"
+      present: 入力しないでください
+      required: 入力してください
+      taken: すでに存在します
+      too_long: "%{count}文字以内で入力してください"
+      too_short: "%{count}文字以上で入力してください"
+      wrong_length: "%{count}文字で入力してください"
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -109,30 +109,30 @@ ja:
   errors:
     format: "%{attribute}%{message}"
     messages:
-      accepted: 受諾してください
-      blank: 入力してください
-      confirmation: "%{attribute}の入力が一致しません"
-      empty: 入力してください
-      equal_to: "%{count}にしてください"
-      even: 偶数にしてください
-      exclusion: 予約されています
-      greater_than: "%{count}より大きい値にしてください"
-      greater_than_or_equal_to: "%{count}以上の値にしてください"
-      inclusion: 一覧にありません
-      invalid: 不正な値です
-      less_than: "%{count}より小さい値にしてください"
-      less_than_or_equal_to: "%{count}以下の値にしてください"
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
       model_invalid: 'バリデーションに失敗しました: %{errors}'
-      not_a_number: 数値で入力してください
-      not_an_integer: 整数で入力してください
-      odd: 奇数にしてください
-      other_than: "%{count}以外の値にしてください"
-      present: 入力しないでください
-      required: 入力してください
-      taken: すでに存在します
-      too_long: "%{count}文字以内で入力してください"
-      too_short: "%{count}文字以上で入力してください"
-      wrong_length: "%{count}文字で入力してください"
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
     template:
       body: 次の項目を確認してください
       header:


### PR DESCRIPTION
# What
新規登録時、カード入力後に初めてバリデーションのチェックが行われるようになっていたのを、ページ毎にチェックし、バリデーションにひっかかった場合はリダイレクトさせるように変更した
エラーメッセージの表示・日本語化
addressモデル（発送元住所）にバリデーションを追加

# Why
登録に失敗した際、原因がわかりやすいようにするため

![validate](https://user-images.githubusercontent.com/56216409/69935611-c5ca7680-1518-11ea-9f68-d00dc45d4a27.gif)
