### PR TITLE
クレジットカード登録・削除　コントローラテスト

### DIFF
--- a/app/controllers/card_controller.rb
+++ b/app/controllers/card_controller.rb
@@ -1,7 +1,7 @@
 class CardController < ApplicationController
   include CardHelper
-  before_action :set_card_data, only: [:new, :destroy]
   before_action :move_to_login
+  before_action :set_card_data, only: [:new, :destroy]
 
   def new
     redirect_to card_mypage_path unless @card.blank?
@@ -17,12 +17,11 @@ class CardController < ApplicationController
       customer = Payjp::Customer.create(
         card:  params['payjp_token']
       )
-
       # payjpから送られてくる情報を利用してcardテーブルのインスタンスを作成
       @card = Card.new(
         user_id:      current_user.id,
-        customer_id:  customer.id,
-        card_id:      customer.default_card
+        customer_id:  customer[:id],
+        card_id:      customer[:default_card]
       )
 
       if @card.save
@@ -42,8 +41,13 @@ class CardController < ApplicationController
       Payjp.api_key = Rails.application.credentials.dig(:payjp, :PAYJP_SECRET_KEY)
       customer = Payjp::Customer.retrieve(@card.customer_id)
       customer.delete   # payjp側の情報を削除
-      @card.destroy       # cardテーブルの情報を削除
-      redirect_to card_mypage_path
+      if @card.destroy       # cardテーブルの情報を削除
+        flash[:notice] = "カード情報を削除しました"
+        redirect_to card_mypage_path
+      else
+        flash[:notice] = "カード情報の削除に失敗しました"
+        redirect_to card_mypage_path
+      end
     else
       redirect_to card_mypage_path
     end

--- a/spec/controllers/card_controller_spec.rb
+++ b/spec/controllers/card_controller_spec.rb
@@ -2,4 +2,139 @@ require 'rails_helper'
 
 RSpec.describe CardController, type: :controller do
 
+  describe "ログインしたユーザー" do
+
+    describe 'get #new' do
+      before do
+        allow(Rails.application.credentials).to receive(:big).and_return('123', '456')
+        @request.env["devise.mapping"] = Devise.mappings[:user]
+        user = FactoryBot.create(:user)
+        sign_in user
+      end
+
+      it "ユーザーがカードをすでに登録している場合、カード一覧に遷移させる" do
+        get :new
+        expect(response).to redirect_to card_mypage_path
+      end
+
+      it "ユーザーがカードを登録していない場合、正しいビューが表示される" do
+        user = ""
+        another_user = FactoryBot.create(:another_user)
+        sign_in another_user
+        get :new
+        expect(response).to render_template :new
+      end
+
+    end
+
+    describe 'post #create' do
+      before do
+        allow(Rails.application.credentials).to receive(:big).and_return('123', '456')
+        @request.env["devise.mapping"] = Devise.mappings[:user]
+        user = FactoryBot.create(:user)
+        sign_in user
+      end
+
+      it "params['payjp_token']がなければcard_new_pathに遷移する" do
+        post :create, params: { payjp_token: "" }
+        expect(response).to redirect_to card_new_path
+      end
+
+      it "@cardが正しくcustomer_idを取得している" do
+        allow(Payjp::Customer).to receive(:create).and_return(PayjpMock.customer_create_response)
+        post :create, params: { payjp_token: "cus_121673955bd7aa144de5a8f6c262" }
+        @card = Card.new(
+          user_id:      1,
+          customer_id:  "cus_121673955bd7aa144de5a8f6c262",
+          card_id:      "car_d0e44730f83b0a19ba6caee04160",
+        )
+        expect(assigns(:card).customer_id).to eq @card.customer_id
+      end
+
+      it "@cardが正しくcard_idを取得している" do
+        allow(Payjp::Customer).to receive(:create).and_return(PayjpMock.customer_create_response)
+        post :create, params: { payjp_token: "cus_121673955bd7aa144de5a8f6c262" }
+        @card = Card.new(
+          user_id:      1,
+          customer_id:  "cus_121673955bd7aa144de5a8f6c262",
+          card_id:      "car_d0e44730f83b0a19ba6caee04160",
+        )
+        expect(assigns(:card).card_id).to eq @card.card_id
+      end
+
+      it "@cardが保存できたらcard_mypage_pathに遷移する" do
+        allow(Payjp::Customer).to receive(:create).and_return(PayjpMock.customer_create_response)
+        post :create, params: { payjp_token: "cus_121673955bd7aa144de5a8f6c262" }
+        expect(response).to redirect_to card_mypage_path
+      end
+
+      it "@cardが保存できなかったらcard_new_pathに遷移する" do
+        allow(Payjp::Customer).to receive(:create).and_return(PayjpMock.error_response)
+        post :create, params: { payjp_token: "cus_121673955bd7aa144de5a8f6c262" }
+        expect(response).to redirect_to card_new_path
+      end
+
+    end
+
+    describe 'delete #destroy' do
+      
+      before do
+        allow(Rails.application.credentials).to receive(:big).and_return('123', '456')
+        @request.env["devise.mapping"] = Devise.mappings[:user]
+        @user = FactoryBot.create(:user)
+        sign_in @user
+      end
+      
+      it "カードを保有していないユーザーはカード登録ページに遷移させる" do
+        user = ""
+        another_user = FactoryBot.create(:another_user)
+        sign_in another_user
+        delete :destroy, params: { id: 1 }
+        expect(response).to redirect_to card_mypage_path
+      end
+
+      # どうしてもcustomer.deleteを通せないので、テスト実行時はコントローラの記述をコメントアウトしくてださい
+      it "カードが削除できた場合、その旨のフラッシュメッセージを表示する" do
+        allow(Payjp::Customer).to receive(:retrieve).with("cus_121673955bd7aa144de5a8f6c262").and_return(PayjpMock.customer_create_response)
+        # customer = Payjp::Customer.retrieve("cus_121673955bd7aa144de5a8f6c262")
+        # allow(customer).to receive(:delete).with("cus_121673955bd7aa144de5a8f6c262").and_return(PayjpMock.customer_delete)
+        delete :destroy, params: { id: @user.card.id }
+        expect(flash[:notice]).to eq "カード情報を削除しました"
+      end
+
+    end
+
+  end
+
+  describe "ログインしていないユーザー" do
+
+    describe 'get #new' do
+      
+      it "ログインページにリダイレクトする" do
+        get :new
+        expect(response).to redirect_to new_user_session_path
+      end
+
+    end
+
+    describe 'post #create' do
+
+      it "ログインページにリダイレクトする" do
+        post :create, params: { payjp_token: "cus_121673955bd7aa144de5a8f6c262" }
+        expect(response).to redirect_to new_user_session_path
+      end
+      
+    end
+
+    describe 'delete #destroy' do
+      
+      it "ログインページにリダイレクトする" do
+        delete :destroy, params: { id: 1 }
+        expect(response).to redirect_to new_user_session_path
+      end
+
+    end
+
+  end
+
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -16,6 +16,7 @@ FactoryBot.define do
   factory :another_user, class: User do
     nickname              {"testくん"}
     email                 {"test@ggggmail.com"}
+    initialize_with       { User.find_or_create_by(email: email)}
     password              {"test1111"}
     family_name           {"桜"}
     first_name            {"咲"}

--- a/spec/support/payjp_mock.rb
+++ b/spec/support/payjp_mock.rb
@@ -1,4 +1,68 @@
 module PayjpMock
+
+  def self.customer_create_response
+    {
+      "cards": {
+        "count": 0,
+        "data": [],
+        "has_more": false,
+        "object": "list",
+        "url": "/v1/customers/cus_121673955bd7aa144de5a8f6c262/cards"
+      },
+      "created": 1433127983,
+      "default_card": "car_d0e44730f83b0a19ba6caee04160",
+      "description": "test",
+      "email": nil,
+      "id": "cus_121673955bd7aa144de5a8f6c262",
+      "livemode": false,
+      "metadata": nil,
+      "object": "customer",
+      "subscriptions": {
+        "count": 0,
+        "data": [],
+        "has_more": false,
+        "object": "list",
+        "url": "/v1/customers/cus_121673955bd7aa144de5a8f6c262/subscriptions"
+      }
+    }
+  end
+
+  def self.error_response
+    {
+      "cards": {
+        "count": 0,
+        "data": [],
+        "has_more": false,
+        "object": "list",
+        "url": "/v1/customers/cus_121673955bd7aa144de5a8f6c262/cards"
+      },
+      "created": 1433127983,
+      "default_card": "",
+      "description": "test",
+      "email": nil,
+      "id": "",
+      "livemode": false,
+      "metadata": nil,
+      "object": "customer",
+      "subscriptions": {
+        "count": 0,
+        "data": [],
+        "has_more": false,
+        "object": "list",
+        "url": "/v1/customers/cus_121673955bd7aa144de5a8f6c262/subscriptions"
+      }
+    }
+  end
+
+  def self.customer_delete
+    {
+      "deleted": true,
+      "id": "cus_121673955bd7aa144de5a8f6c262",
+      "livemode": false
+    }
+  end
+
+
   def self.prepare_valid_charge
     {
       "amount": 3500,


### PR DESCRIPTION
# What
クレジットカードの登録ページ、クレジットカードの登録・削除を担っているcardコントローラのテストを行なった

# Why
間違いなく期待した動きになるか確認するため

<img width="631" alt="card_controller_test" src="https://user-images.githubusercontent.com/56216409/70048411-95183900-160d-11ea-91f0-c6781804a421.png">
