### PR TITLE
パスワードを表示するボタン

### DIFF
--- a/app/assets/javascripts/signup.js
+++ b/app/assets/javascripts/signup.js
@@ -8,3 +8,35 @@ $(function(){
     $('#user_birthday').val(birthday)
   });
 })
+
+// パスワードを表示する
+$(function(){
+  let swow_password_box = $(".user-form__content__password__check__show")
+
+  function showPassword(password) {
+    let html = `<span class="form-password-revelation-revealed-password">${ password }</span>`
+    swow_password_box.append(html)
+  }
+
+  // パスワードの取得表示
+  $('#user_password').on("keyup", function(e) {
+    e.preventDefault();
+    swow_password_box.empty();
+    let password = $("#user_password").val();
+    if (password.length !== 0) {
+      showPassword(password)
+    }
+  });
+
+  // 表示非表示、チェックボックスカラー
+  let password_show_box = $('.user-form__content__password__check__show');
+  $('#password-check').click(function(){
+    password_show_box.toggle();
+    let check_mark = ('#password-check-mark')
+    if (password_show_box.is(':visible')) {
+      $(check_mark).css('background-color', '#0099e8');
+    } else {
+      $(check_mark).css('background-color', '#fff');
+    }
+  });
+});

--- a/app/assets/stylesheets/_signup.scss
+++ b/app/assets/stylesheets/_signup.scss
@@ -153,6 +153,25 @@
           color: #888;
           font-size: 14px;
         }
+        &__password {
+          &__check {
+            &__show {
+              display: none;
+              line-height: 1.5;
+              font-size: 16px;
+              font-weight: 500;
+              font-family: monospace;
+              margin: 14px 0;
+              word-break: break-all;
+              overflow-wrap: break-word;
+              span {
+                display: inline-block;
+                background-color: #f5f5f5;
+                padding: 4px 8px;
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -7,7 +7,6 @@ class SignupController < ApplicationController
 
   def registration
     status_bar("active", "", "", "", "")
-    
   end
 
   def sms_confirmation           #電話番号確認

--- a/app/views/signup/registration.html.haml
+++ b/app/views/signup/registration.html.haml
@@ -40,12 +40,11 @@
                     = "パスワード#{error}"
                     %br
               .user-form__content__password__check
-                .checkbox-default
+                .checkbox-default#password-check
                   %input
-                    %i.fa.fa-check
+                    %i.fa.fa-check#password-check-mark
                     %label パスワードを表示する
-                  .user-form__content__password__check__show
-                    %span.user-password-show
+                .user-form__content__password__check__show
 
           .user-form__content__group
             %h3.sub-title 本人確認


### PR DESCRIPTION
# What
ユーザー新規登録時に、入力したパスワードを目視できるようにした

# Why
パスワードの打ち間違いを防ぐため
![b97d4b0b094e250e31d9a062fd08a278](https://user-images.githubusercontent.com/56216409/70199133-3c06ed00-1754-11ea-9923-c2edcd873926.gif)
